### PR TITLE
Enforce utf-8 encoding

### DIFF
--- a/medcat/preprocessing/iterators.py
+++ b/medcat/preprocessing/iterators.py
@@ -146,6 +146,6 @@ class SimpleIter(object):
         self.text_path = text_path
 
     def __iter__(self):
-        data = open(self.text_path)
+        data = open(self.text_path, encoding='utf-8')
         for line in data:
             yield str(line).strip().split(" ")

--- a/medcat/utils/make_vocab.py
+++ b/medcat/utils/make_vocab.py
@@ -73,7 +73,7 @@ class MakeVocab(object):
         out_path = os.path.join(out_folder, "data.txt")
         vocab_path = os.path.join(out_folder, "vocab.dat")
         self.vocab_path = vocab_path
-        out = open(out_path, 'w')
+        out = open(out_path, 'w', encoding='utf-8')
 
         for ind, doc in enumerate(iter_data):
             if ind % 10000 == 0:


### PR DESCRIPTION
This PR specifies an explicit encoding for reading/writing text with UTF-8. Without these changes, I got a `UnicodeEncodeError` when running `make_vocab.make()`, as my text for training the model was encoded with UTF-8.

This might not be the most elegant fix, but UTF-8 seems like a sensible standard, especially for non-English use cases (my text is in Dutch), and this will at least prevent any silent issues.

There are other lines where the encoding could be specified, but these 2 changes seemed to be the only necessary ones for me. 

P.S. I'm working together with @sandertan; he confirmed that these changes did not break anything on his end.