### PR TITLE
Fix version of tokenizers version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,1 @@
-spacy==2.2.4
-gensim~=3.7
-scipy~=1.4
-Flask~=1.1
-numpy~=1.18
-pandas~=1.0
-tokenizers~=0.7
-torch~=1.4.0
-torchvision~=0.5.0
-sklearn~=0.0
-elasticsearch==7.9.1
+.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         'gensim~=3.7',
         'spacy==2.2.4',
         'scipy~=1.4',
-        'tokenizers~=0.8',
+        'tokenizers~=0.8.0',
         'torch~=1.4.0',
         'torchvision~=0.5.0',
         'Flask~=1.1',


### PR DESCRIPTION
@w-is-h This fixes the failing test in https://github.com/CogStack/MedCATservice/pull/11.

It was caused by a difference in version of `tokenizers`. In `setup.py` it was set to `~=0.8`, which actually installed `0.9.4`, the latest release. The `0.9.x` release contained the code change that made the test fail. I just learned the hard way that to use the latest version `0.8.x`, it should be set to `~=0.8.0`.

While fixing this, I noticed a difference between the `requirements.txt` and `setup.py` in `tokenizers` version. Assuming `0.8.x` is the intended version, I synced them by just putting a single `.` in `requirements.py`. Also just learned to do that :)
https://stackoverflow.com/a/19081268/4141535

Also note that in https://github.com/CogStack/MedCATservice/blob/master/medcat_service/requirements.txt the medcat version is set to `medcat~=0.3`, which means it downloads the latest `0.x` version. When there's a stable release, perhaps it's best to set it to a specific version to avoid suddenly changed results.