### PR TITLE
Fix eval() in MetaCAT

### DIFF
--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -6,7 +6,7 @@ import torch
 from scipy.special import softmax
 
 from medcat.utils.ml_utils import train_network, eval_network
-from medcat.utils.data_utils import prepare_from_json, encode_category_values, tkns_to_ids, set_all_seeds
+from medcat.utils.data_utils import prepare_from_json, encode_category_values, set_all_seeds
 from medcat.preprocessing.tokenizers import TokenizerWrapperBPE
 from medcat.preprocessing.tokenizers import TokenizerWrapperBERT
 
@@ -76,9 +76,6 @@ class MetaCAT(object):
             # We already have everything, just get the data
             data, _ = encode_category_values(data, vals=self.category_values)
 
-        # Convert data tkns to ids
-        #data = tkns_to_ids(data, self.tokenizer)
-
         if not fine_tune:
             if model_name == 'lstm':
                 from medcat.utils.models import LSTM
@@ -144,7 +141,7 @@ class MetaCAT(object):
         data = json.load(open(json_path, 'r'))
 
         # Prepare the data
-        data = prepare_from_json(data, self.cntx_left, self.cntx_right, self.tokenizer, lowercase=lowercase, cui_filter=cui_filter,
+        data = prepare_from_json(data, self.cntx_left, self.cntx_right, self.tokenizer, cui_filter=cui_filter,
                 replace_center=replace_center)
 
         # Check is the name there
@@ -155,9 +152,6 @@ class MetaCAT(object):
 
         # We already have everything, just get the data
         data, _ = encode_category_values(data, vals=self.category_values)
-
-        # Convert data tkns to ids
-        data = tkns_to_ids(data, self.tokenizer)
 
         # Run evaluation
         result = eval_network(self.model, data, max_seq_len=(self.cntx_left+self.cntx_right+1), pad_id=self.pad_id,

--- a/medcat/utils/data_utils.py
+++ b/medcat/utils/data_utils.py
@@ -977,15 +977,6 @@ def encode_category_values(data, vals=None):
     return data, vals
 
 
-def tkns_to_ids(data, tokenizer):
-    data = list(data)
-
-    for i in range(len(data)):
-        data[i][1] = [tokenizer.convert_tokens_to_ids(tok) for tok in data[i][1]]
-
-    return data
-
-
 def make_mc_train_test(data, cdb, seed=17, test_size=0.2):
     """ This is a disaster
     """


### PR DESCRIPTION
`tkns_to_ids()` was already commented out in `MetaCAT.train()`, so I removed it from `MetaCAT.eval()` as well. Since there is no functionality left for this function, I removed it entirely... Are you okay with that @w-is-h or do you intend to repurpose it?

Also, I removed  `lowercase=lowercase` from `prepare_from_json()` in `eval()` to align it with `train()`.