### PR TITLE
Tokenizer add prefix space

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -4,7 +4,7 @@ import time
 import logging
 from functools import partial
 from copy import deepcopy
-from tqdm.autonotebook import tqdm
+from tqdm import tqdm
 from multiprocessing import Process, Manager, Queue, Pool, Array
 from time import sleep
 

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -270,9 +270,9 @@ class MetaCAT(object):
         # Load tokenizer if it is None
         if self.tokenizer is None:
             if 'bbpe' in tokenizer_name:
-                self.tokenizer = TokenizerWrapperBPE.load(self.save_dir, name=tokenizer_name)
+                self.tokenizer = TokenizerWrapperBPE.load(self.save_dir, name=tokenizer_name, **kwargs)
             elif 'bert' in tokenizer_name:
-                self.tokenizer = TokenizerWrapperBERT.load(self.save_dir, name=tokenizer_name)
+                self.tokenizer = TokenizerWrapperBERT.load(self.save_dir, name=tokenizer_name, **kwargs)
             else:
                 raise Exception("Tokenizer not supported")
         # Load embeddings if None

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -34,10 +34,6 @@ class MetaCAT(object):
 
         self.model = None
 
-        # TODO: A shitty solution, make right at some point
-        if not self.save_dir.endswith("/"):
-            self.save_dir = self.save_dir + "/"
-
 
     def train(self, json_path, category_name=None, model_name='lstm', lr=0.01, test_size=0.1,
               batch_size=100, nepochs=20, class_weights=None, cv=0,
@@ -196,7 +192,7 @@ class MetaCAT(object):
                 # The tokenizer wrapper saving  
                 self.tokenizer.save(self.save_dir, name=tokenizer_name)
             # Save embeddings
-            np.save(open(self.save_dir + "embeddings.npy", 'wb'), np.array(self.embeddings))
+            np.save(os.path.join(self.save_dir, 'embeddings.npy'), np.array(self.embeddings))
 
         # The lstm model is saved during training, don't do it here
         #save the config.
@@ -205,7 +201,7 @@ class MetaCAT(object):
 
     def save_config(self):
         # TODO: Add other parameters, e.g replace_center, ignore_cpos etc.
-        path = self.save_dir + "vars.dat"
+        path = os.path.join(self.save_dir, 'vars.dat')
         to_save = {'category_name': self.category_name,
                    'category_values': self.category_values,
                    'i_category_values': self.i_category_values,
@@ -220,7 +216,7 @@ class MetaCAT(object):
     def load_config(self):
         """ Loads variables of this object
         """
-        path = self.save_dir + "vars.dat"
+        path = os.path.join(self.save_dir, 'vars.dat')
         with open(path, 'rb') as f:
             to_load = pickle.load(f)
 
@@ -246,21 +242,21 @@ class MetaCAT(object):
 
             self.model = LSTM(self.embeddings, self.pad_id, nclasses=nclasses, bid=bid, num_layers=num_layers,
                          input_size=input_size, hidden_size=hidden_size, dropout=dropout)
-            path = self.save_dir + "lstm.dat"
+            path = os.path.join(self.save_dir, 'lstm.dat')
 
         self.model.load_state_dict(torch.load(path, map_location=self.device))
 
     @classmethod
-    def load(cls, save_dir, model='lstm'):
+    def load(cls, save_dir, model='lstm', **kwargs):
         ''' Load from full save
         '''
         mc = cls(save_dir=save_dir)
-        mc._load(model=model)
+        mc._load(model=model, **kwargs)
 
         return mc
 
 
-    def _load(self, model='lstm'):
+    def _load(self, model='lstm', **kwargs):
         """ Loads model and config for this meta annotation
         """
         # Load configuration
@@ -277,7 +273,7 @@ class MetaCAT(object):
                 raise Exception("Tokenizer not supported")
         # Load embeddings if None
         if self.embeddings is None:
-            embeddings = np.load(open(self.save_dir  + "embeddings.npy", 'rb'), allow_pickle=False)
+            embeddings = np.load(os.path.join(self.save_dir, 'embeddings.npy'), allow_pickle=False)
             self.embeddings = torch.tensor(embeddings, dtype=torch.float32)
 
         # Load MODEL

--- a/medcat/preprocessing/tokenizers.py
+++ b/medcat/preprocessing/tokenizers.py
@@ -151,11 +151,13 @@ class TokenizerWrapperBPE(object):
         self.hf_tokenizers.save_model(dir_path, name=name)
 
     @classmethod
-    def load(cls, dir_path, name='bbpe', lowercase=True):
+    def load(cls, dir_path, name='bbpe', **kwargs):
         tokenizer = cls()
-        vocab_file = dir_path + "{}-vocab.json".format(name)
-        merges_file = dir_path + "{}-merges.txt".format(name)
-        tokenizer.hf_tokenizers = ByteLevelBPETokenizer.from_file(vocab_filename=vocab_file, merges_filename=merges_file, lowercase=lowercase)
+        vocab_file = os.path.join(dir_path, f'{name}-vocab.json')
+        merges_file = os.path.join(dir_path, f'{name}-merges.txt')
+        tokenizer.hf_tokenizers = ByteLevelBPETokenizer.from_file(vocab_filename=vocab_file,
+                                                                  merges_filename=merges_file,
+                                                                  **kwargs)
 
         return tokenizer
 
@@ -183,9 +185,9 @@ class TokenizerWrapperBERT(object):
         self.hf_tokenizers.save_pretrained(path)
 
     @classmethod
-    def load(cls, dir_path, name='bert', lowercase=True):
+    def load(cls, dir_path, name='bert', **kwargs):
         tokenizer = cls()
         path = os.path.join(dir_path, name)
-        tokenizer.hf_tokenizers = BertTokenizerFast.from_pretrained(path)
+        tokenizer.hf_tokenizers = BertTokenizerFast.from_pretrained(path, **kwargs)
 
         return tokenizer

--- a/medcat/utils/ml_utils.py
+++ b/medcat/utils/ml_utils.py
@@ -6,6 +6,7 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 import torch.optim as optim
+import os
 
 
 def get_lr_linking(config, cui_count, params, similarity):
@@ -173,7 +174,7 @@ def train_network(net, data, lr=0.01, test_size=0.1, max_seq_len=41, pad_id=3000
         if f1 > best_f1:
             print("=" * 50)
             if auto_save_model:
-                path = save_dir + "lstm.dat"
+                path = os.path.join(save_dir, "lstm.dat")
                 torch.save(net.state_dict(), path)
                 print("Model saved at epoch: {} and f1: {}".format(epoch, f1))
 


### PR DESCRIPTION
We were encountering an issue that the presence or absence of a space in front of the first word of a sentence changed the results from MetaCAT. This issue occurred relatively often, because our negation training data mostly consists of short texts, so many sentence don't have a space at the start. In longer, real texts, there are probably a lot less of these sentences, see https://discuss.huggingface.co/t/bpe-tokenizers-and-spaces-before-words/475/2 . 

This was solvable with adding a parameter to the tokenizer:
```python
tokenizer = ByteLevelBPETokenizer(add_prefix_space=True)
```

The previous code didn't allow for adding parameters during loading a previously saved tokenizer, so I changed that. I made it flexible (`**kwargs`) so that other parameters can also easily be set. In the future it would be nice to auto-save/load the parameters with the tokenizer itself, but that's something for a future PR.

I also did some cleaning with the path creation statements and solved a warning.