### PR TITLE
Add pipes to cat_ner and cat_liner

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -755,7 +755,7 @@ p
         r''' Run multiprocessing NOT FOR TRAINING
 
         in_data:  a list with format: [(id, text), (id, text), ...]
-        nproc:  the number of processors (when set to 1, batch_size will be ignored. Instead, workers and batch_size in Config are honoured)
+        nproc:  the number of processors (when set to 1, workers in Config is honoured during component-level multiprocessing)
         batch_size: the number of texts to buffer
 
         return:  an list of tuples: [(id, doc_json), (id, doc_json), ...] or if return_dict is True, a dict: {id: doc_json, id: doc_json, ...}

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -635,11 +635,13 @@ p
         '''
         out: Union[Dict, List[Union[Dict, None]]]
         cnf_annotation_output = getattr(self.config, 'annotation_output', {})
-        if text is None or isinstance(text, str):
+        if text is None:
+            out = self._doc_to_out(None, cnf_annotation_output, only_cui, addl_info)
+        elif isinstance(text, str):
             doc = self(text)
             out = self._doc_to_out(doc, cnf_annotation_output, only_cui, addl_info)
         else:
-            if n_process is None or n_process == 1:
+            if n_process is None:
                 out = []
                 docs = self(self._generate_trimmed_texts(text))
                 for doc in docs:
@@ -652,6 +654,7 @@ p
                     docs = self.pipe.batch_multi_process(texts, n_process, batch_size, len(texts))
 
                     for doc in docs:
+                        doc = None if doc.text.strip() == '' else doc
                         out.append(self._doc_to_out(doc, cnf_annotation_output, only_cui, addl_info))
 
                     # Currently spaCy cannot mark which pieces of texts failed within the pipe so be this workaround,
@@ -743,7 +746,7 @@ p
 
     def multiprocessing_pipe(self,
                              in_data: Union[List[Tuple], Iterable[Tuple]],
-                             nproc: Optional[int] = None,
+                             nproc: Optional[int] = 1,  # 1 because multiprocessing will be conducted inside pipeline components so as to work with multi-core GPUs.
                              batch_size: Optional[int] = None,
                              only_cui: bool = False,
                              addl_info: List[str] = [],
@@ -870,7 +873,7 @@ p
         return out
 
     def _get_trimmed_text(self, text: str) -> Optional[str]:
-        return text[0:self.config.preprocessing.get('max_document_length')] if text is not None and len(text) > 0 else None
+        return text[0:self.config.preprocessing.get('max_document_length')] if text is not None and len(text) > 0 else ""
 
     def _generate_trimmed_texts(self, texts: Union[Iterable[str], Iterable[Tuple]]) -> Generator[Optional[str], None, None]:
         for text in texts:

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -746,7 +746,7 @@ p
 
     def multiprocessing_pipe(self,
                              in_data: Union[List[Tuple], Iterable[Tuple]],
-                             nproc: Optional[int] = None,
+                             nproc: Optional[int] = 1,
                              batch_size: Optional[int] = None,
                              only_cui: bool = False,
                              addl_info: List[str] = [],
@@ -755,7 +755,7 @@ p
         r''' Run multiprocessing NOT FOR TRAINING
 
         in_data:  a list with format: [(id, text), (id, text), ...]
-        nproc:  the number of processors
+        nproc:  the number of processors (when set to 1, batch_size will be ignored. Instead, workers and batch_size in Config are honoured)
         batch_size: the number of texts to buffer
 
         return:  an list of tuples: [(id, doc_json), (id, doc_json), ...] or if return_dict is True, a dict: {id: doc_json, id: doc_json, ...}

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -746,7 +746,7 @@ p
 
     def multiprocessing_pipe(self,
                              in_data: Union[List[Tuple], Iterable[Tuple]],
-                             nproc: Optional[int] = 1,  # 1 because multiprocessing will be conducted inside pipeline components so as to work with multi-core GPUs.
+                             nproc: Optional[int] = None,
                              batch_size: Optional[int] = None,
                              only_cui: bool = False,
                              addl_info: List[str] = [],

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -9,7 +9,7 @@ from functools import partial
 
 from medcat.utils.matutils import unitvec, sigmoid
 from medcat.utils.ml_utils import get_lr_linking
-from medcat.config import Config, weighted_average, n_process_and_batch_size
+from medcat.config import Config, weighted_average, workers_and_batch_size
 
 
 class CDB(object):
@@ -387,13 +387,13 @@ class CDB(object):
                 if callable(weighted_average_function) and getattr(weighted_average_function, "__name__", None) == "<lambda>":
                     config.linking['weighted_average_function'] = partial(weighted_average, factor=0.0004)
                 if getattr(config.ner, 'n_process', None) is None:
-                    config.ner['n_process'] = n_process_and_batch_size()['n_process']
+                    config.ner['workers'] = workers_and_batch_size()['workers']
                 if getattr(config.ner, 'batch_size', None) is None:
-                    config.ner['batch_size'] = n_process_and_batch_size()['batch_size']
+                    config.ner['batch_size'] = workers_and_batch_size()['batch_size']
                 if getattr(config.linking, 'n_process', None) is None:
-                    config.linking['n_process'] = n_process_and_batch_size()['n_process']
+                    config.linking['workers'] = workers_and_batch_size()['workers']
                 if getattr(config.linking, 'batch_size', None) is None:
-                    config.linking['batch_size'] = n_process_and_batch_size()['batch_size']
+                    config.linking['batch_size'] = workers_and_batch_size()['batch_size']
 
             # Create an instance of the CDB (empty)
             cdb = cls(config=config)

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -386,14 +386,14 @@ class CDB(object):
                 weighted_average_function = config.linking['weighted_average_function']
                 if callable(weighted_average_function) and getattr(weighted_average_function, "__name__", None) == "<lambda>":
                     config.linking['weighted_average_function'] = partial(weighted_average, factor=0.0004)
-                if getattr(config.ner, 'n_process', None) is None:
-                    config.ner['workers'] = workers_and_batch_size()['workers']
+                if getattr(config.ner, 'workers', None) is None:
+                    config.ner['workers'] = workers_and_batch_size(load_size=10000)['workers']
                 if getattr(config.ner, 'batch_size', None) is None:
-                    config.ner['batch_size'] = workers_and_batch_size()['batch_size']
-                if getattr(config.linking, 'n_process', None) is None:
-                    config.linking['workers'] = workers_and_batch_size()['workers']
+                    config.ner['batch_size'] = workers_and_batch_size(load_size=10000)['batch_size']
+                if getattr(config.linking, 'workers', None) is None:
+                    config.linking['workers'] = workers_and_batch_size(load_size=10000)['workers']
                 if getattr(config.linking, 'batch_size', None) is None:
-                    config.linking['batch_size'] = workers_and_batch_size()['batch_size']
+                    config.linking['batch_size'] = workers_and_batch_size(load_size=10000)['batch_size']
 
             # Create an instance of the CDB (empty)
             cdb = cls(config=config)

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -9,7 +9,7 @@ from functools import partial
 
 from medcat.utils.matutils import unitvec, sigmoid
 from medcat.utils.ml_utils import get_lr_linking
-from medcat.config import Config, weighted_average, workers_and_batch_size
+from medcat.config import Config, weighted_average, workers
 
 
 class CDB(object):
@@ -387,13 +387,9 @@ class CDB(object):
                 if callable(weighted_average_function) and getattr(weighted_average_function, "__name__", None) == "<lambda>":
                     config.linking['weighted_average_function'] = partial(weighted_average, factor=0.0004)
                 if getattr(config.ner, 'workers', None) is None:
-                    config.ner['workers'] = workers_and_batch_size(load_size=10000)['workers']
-                if getattr(config.ner, 'batch_size', None) is None:
-                    config.ner['batch_size'] = workers_and_batch_size(load_size=10000)['batch_size']
+                    config.ner['workers'] = workers()
                 if getattr(config.linking, 'workers', None) is None:
-                    config.linking['workers'] = workers_and_batch_size(load_size=10000)['workers']
-                if getattr(config.linking, 'batch_size', None) is None:
-                    config.linking['batch_size'] = workers_and_batch_size(load_size=10000)['batch_size']
+                    config.linking['workers'] = workers()
 
             # Create an instance of the CDB (empty)
             cdb = cls(config=config)

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -9,7 +9,7 @@ from functools import partial
 
 from medcat.utils.matutils import unitvec, sigmoid
 from medcat.utils.ml_utils import get_lr_linking
-from medcat.config import Config, weighted_average
+from medcat.config import Config, weighted_average, n_process_and_batch_size
 
 
 class CDB(object):
@@ -386,6 +386,11 @@ class CDB(object):
                 weighted_average_function = config.linking['weighted_average_function']
                 if callable(weighted_average_function) and getattr(weighted_average_function, "__name__", None) == "<lambda>":
                     config.linking['weighted_average_function'] = partial(weighted_average, factor=0.0004)
+                if getattr(config.ner, 'n_process', None) is None:
+                    config.ner['n_process'] = n_process_and_batch_size()['n_process']
+                if getattr(config.ner, 'batch_size', None) is None:
+                    config.ner['batch_size'] = n_process_and_batch_size()['batch_size']
+
             # Create an instance of the CDB (empty)
             cdb = cls(config=config)
 

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -390,6 +390,10 @@ class CDB(object):
                     config.ner['n_process'] = n_process_and_batch_size()['n_process']
                 if getattr(config.ner, 'batch_size', None) is None:
                     config.ner['batch_size'] = n_process_and_batch_size()['batch_size']
+                if getattr(config.linking, 'n_process', None) is None:
+                    config.linking['n_process'] = n_process_and_batch_size()['n_process']
+                if getattr(config.linking, 'batch_size', None) is None:
+                    config.linking['batch_size'] = n_process_and_batch_size()['batch_size']
 
             # Create an instance of the CDB (empty)
             cdb = cls(config=config)

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -10,11 +10,11 @@ def weighted_average(step, factor):
     return max(0.1, 1 - (step ** 2 * factor))
 
 
-def n_process_and_batch_size(n_process=None, batch_size=None, total_size=1000, batch_factor=2):
-    n_process = max(cpu_count() - 1, 1) if n_process is None else n_process
-    batch_size = math.ceil(total_size / (batch_factor * n_process)) if batch_size is None else batch_size
+def workers_and_batch_size(workers=None, batch_size=None, total_size=1000, batch_factor=2):
+    workers = max(cpu_count() - 1, 1) if workers is None else workers
+    batch_size = math.ceil(total_size / (batch_factor * workers)) if batch_size is None else batch_size
     return {
-        "n_process": n_process,
+        "workers": workers,
         "batch_size": batch_size
     }
 
@@ -104,10 +104,10 @@ class Config(object):
                 'upper_case_limit_len': 3,
                 # Try reverse word order for short concepts (2 words max), e.g. heart disease -> disease heart
                 'try_reverse_word_order': False,
-                # Number of processors used by the NER pipeline component
-                'n_process': n_process_and_batch_size()["n_process"],
+                # Number of workers used by the NER pipeline component
+                'workers': workers_and_batch_size()["workers"],
                 # Batch size used by the NER pipeline component during multiprocessing
-                'batch_size': n_process_and_batch_size()["batch_size"],
+                'batch_size': workers_and_batch_size()["workers"],
                 }
 
         self.linking = {
@@ -158,10 +158,10 @@ class Config(object):
                 'filters': {
                     'cuis': set(), # CUIs in this filter will be included, everything else excluded, must be a set, if empty all cuis will be included
                     },
-                # Number of processors used by the Linker pipeline component
-                'n_process': n_process_and_batch_size()["n_process"],
+                # Number of workers used by the Linker pipeline component
+                'workers': workers_and_batch_size()["workers"],
                 # Batch size used by the Linker pipeline component during multiprocessing
-                'batch_size': n_process_and_batch_size()["batch_size"],
+                'batch_size': workers_and_batch_size()["batch_size"],
                 }
 
 

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -1,11 +1,23 @@
 import re
 import logging
 import jsonpickle
+import math
 from functools import partial
+from multiprocessing import cpu_count
 
 
 def weighted_average(step, factor):
     return max(0.1, 1 - (step ** 2 * factor))
+
+
+def n_process_and_batch_size(override_n_process=None, override_batch_size=None, total_size=1000, batch_factor=2):
+    n_process = max(cpu_count() - 1, 1) if override_n_process is None else override_n_process
+    batch_size = math.ceil(total_size / (batch_factor * n_process)) if override_batch_size is None else override_batch_size
+    return {
+        "n_process": n_process,
+        "batch_size": batch_size
+    }
+
 
 class Config(object):
 
@@ -92,6 +104,10 @@ class Config(object):
                 'upper_case_limit_len': 3,
                 # Try reverse word order for short concepts (2 words max), e.g. heart disease -> disease heart
                 'try_reverse_word_order': False,
+                # Number of processors used by the NER pipeline component
+                'n_process': n_process_and_batch_size()["n_process"],
+                # Batch size used by the NER pipeline component during multiprocessing
+                'batch_size': n_process_and_batch_size()["batch_size"],
                 }
 
         self.linking = {

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -1,7 +1,6 @@
 import re
 import logging
 import jsonpickle
-import math
 from functools import partial
 from multiprocessing import cpu_count
 
@@ -10,13 +9,8 @@ def weighted_average(step, factor):
     return max(0.1, 1 - (step ** 2 * factor))
 
 
-def workers_and_batch_size(load_size, batch_size=None, batch_factor=2, workers=None):
-    workers = max(cpu_count() - 1, 1) if workers is None else workers
-    batch_size = math.ceil(load_size / (batch_factor * workers)) if batch_size is None else batch_size
-    return {
-        "workers": workers,
-        "batch_size": batch_size
-    }
+def workers(workers_override=None):
+    return max(cpu_count() - 1, 1) if workers_override is None else workers_override
 
 
 class Config(object):
@@ -105,9 +99,7 @@ class Config(object):
                 # Try reverse word order for short concepts (2 words max), e.g. heart disease -> disease heart
                 'try_reverse_word_order': False,
                 # Number of workers used by the NER pipeline component
-                'workers': workers_and_batch_size(load_size=10000)["workers"],
-                # Batch size used by the NER pipeline component during multiprocessing
-                'batch_size': workers_and_batch_size(load_size=10000)["workers"],
+                'workers': workers(),
                 }
 
         self.linking = {
@@ -159,9 +151,7 @@ class Config(object):
                     'cuis': set(), # CUIs in this filter will be included, everything else excluded, must be a set, if empty all cuis will be included
                     },
                 # Number of workers used by the Linker pipeline component
-                'workers': workers_and_batch_size(load_size=10000)["workers"],
-                # Batch size used by the Linker pipeline component during multiprocessing
-                'batch_size': workers_and_batch_size(load_size=10000)["batch_size"],
+                'workers': workers(),
                 }
 
 

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -10,9 +10,9 @@ def weighted_average(step, factor):
     return max(0.1, 1 - (step ** 2 * factor))
 
 
-def n_process_and_batch_size(override_n_process=None, override_batch_size=None, total_size=1000, batch_factor=2):
-    n_process = max(cpu_count() - 1, 1) if override_n_process is None else override_n_process
-    batch_size = math.ceil(total_size / (batch_factor * n_process)) if override_batch_size is None else override_batch_size
+def n_process_and_batch_size(n_process=None, batch_size=None, total_size=1000, batch_factor=2):
+    n_process = max(cpu_count() - 1, 1) if n_process is None else n_process
+    batch_size = math.ceil(total_size / (batch_factor * n_process)) if batch_size is None else batch_size
     return {
         "n_process": n_process,
         "batch_size": batch_size
@@ -157,7 +157,11 @@ class Config(object):
                 # Filters
                 'filters': {
                     'cuis': set(), # CUIs in this filter will be included, everything else excluded, must be a set, if empty all cuis will be included
-                    }
+                    },
+                # Number of processors used by the Linker pipeline component
+                'n_process': n_process_and_batch_size()["n_process"],
+                # Batch size used by the Linker pipeline component during multiprocessing
+                'batch_size': n_process_and_batch_size()["batch_size"],
                 }
 
 

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -10,9 +10,9 @@ def weighted_average(step, factor):
     return max(0.1, 1 - (step ** 2 * factor))
 
 
-def workers_and_batch_size(workers=None, batch_size=None, total_size=1000, batch_factor=2):
+def workers_and_batch_size(load_size, batch_size=None, batch_factor=2, workers=None):
     workers = max(cpu_count() - 1, 1) if workers is None else workers
-    batch_size = math.ceil(total_size / (batch_factor * workers)) if batch_size is None else batch_size
+    batch_size = math.ceil(load_size / (batch_factor * workers)) if batch_size is None else batch_size
     return {
         "workers": workers,
         "batch_size": batch_size
@@ -105,9 +105,9 @@ class Config(object):
                 # Try reverse word order for short concepts (2 words max), e.g. heart disease -> disease heart
                 'try_reverse_word_order': False,
                 # Number of workers used by the NER pipeline component
-                'workers': workers_and_batch_size()["workers"],
+                'workers': workers_and_batch_size(load_size=10000)["workers"],
                 # Batch size used by the NER pipeline component during multiprocessing
-                'batch_size': workers_and_batch_size()["workers"],
+                'batch_size': workers_and_batch_size(load_size=10000)["workers"],
                 }
 
         self.linking = {
@@ -159,9 +159,9 @@ class Config(object):
                     'cuis': set(), # CUIs in this filter will be included, everything else excluded, must be a set, if empty all cuis will be included
                     },
                 # Number of workers used by the Linker pipeline component
-                'workers': workers_and_batch_size()["workers"],
+                'workers': workers_and_batch_size(load_size=10000)["workers"],
                 # Batch size used by the Linker pipeline component during multiprocessing
-                'batch_size': workers_and_batch_size()["batch_size"],
+                'batch_size': workers_and_batch_size(load_size=10000)["batch_size"],
                 }
 
 

--- a/medcat/linking/context_based_linker.py
+++ b/medcat/linking/context_based_linker.py
@@ -25,7 +25,7 @@ class Linker(PipeRunner):
         self.context_model = ContextModel(self.cdb, self.vocab, self.config)
         # Counter for how often did a pair (name,cui) appear and was used during training
         self.train_counter = {}
-        super().__init__(self.config.linking['workers'], self.config.linking['batch_size'])
+        super().__init__(self.config.linking['workers'])
 
     def _train(self, cui, entity, doc, add_negative=True):
         name = "{} - {}".format(entity._.detected_name, cui)

--- a/medcat/linking/context_based_linker.py
+++ b/medcat/linking/context_based_linker.py
@@ -1,15 +1,11 @@
 import random
 import logging
-import joblib
-from typing import Iterable, Generator
-from spacy.tokens import Doc
-from spacy.tokens.underscore import Underscore
-from spacy.util import minibatch
 from medcat.utils.filters import check_filters
 from medcat.linking.vector_context_model import ContextModel
+from medcat.pipeline.pipe_runner import PipeRunner
 
 
-class Linker(object):
+class Linker(PipeRunner):
     r''' Link to a biomedical database.
 
     Args:
@@ -29,6 +25,7 @@ class Linker(object):
         self.context_model = ContextModel(self.cdb, self.vocab, self.config)
         # Counter for how often did a pair (name,cui) appear and was used during training
         self.train_counter = {}
+        super().__init__(self.config.linking['workers'], self.config.linking['batch_size'])
 
     def _train(self, cui, entity, doc, add_negative=True):
         name = "{} - {}".format(entity._.detected_name, cui)
@@ -44,24 +41,6 @@ class Linker(object):
             if add_negative and self.config.linking['negative_probability'] >= random.random():
                 self.context_model.train_using_negative_sampling(cui)
             self.train_counter[name] = self.train_counter.get(name, 0) + 1
-
-    def pipe(self, stream: Iterable[Doc], batch_size: int = None, n_process: int = None) -> Generator[Doc, None, None]:
-        batch_size = self.config.ner['batch_size'] if batch_size is None else batch_size
-        n_process = self.config.ner['n_process'] if n_process is None else n_process
-        execute = joblib.Parallel(n_jobs=n_process)
-        for docs in minibatch(stream, size=batch_size):
-            try:
-                run_pipe_on_one = joblib.delayed(Linker._run_pipe_on_one)
-                tasks = (run_pipe_on_one(self, doc, Underscore.get_state()) for doc in docs)
-                yield from execute(tasks)
-            except Exception as e:
-                self.log.warning(e, stack_info=True)
-                self.log.warning("Docs contained in the failed mini batch:")
-                for doc in docs:
-                    if hasattr(doc, "text"):
-                        self.log.warning("{}...".format(doc.text[:50]))
-                yield from docs
-
 
     def __call__(self, doc):
         r'''
@@ -166,8 +145,3 @@ class Linker(object):
                     main_anns.append(ent)
 
         doc.ents = list(doc.ents) + main_anns
-
-    @staticmethod
-    def _run_pipe_on_one(ner, doc, underscore_state):
-        Underscore.load_state(underscore_state)
-        return ner(doc)

--- a/medcat/ner/vocab_based_ner.py
+++ b/medcat/ner/vocab_based_ner.py
@@ -14,7 +14,7 @@ class NER(PipeRunner):
     def __init__(self, cdb, config):
         self.config = config
         self.cdb = cdb
-        super().__init__(self.config.linking['workers'], self.config.linking['batch_size'])
+        super().__init__(self.config.linking['workers'])
 
     def __call__(self, doc):
         r''' Detect candidates for concepts - linker will then be able to do the rest. It adds `entities` to the

--- a/medcat/ner/vocab_based_ner.py
+++ b/medcat/ner/vocab_based_ner.py
@@ -2,6 +2,7 @@ import logging
 import joblib
 from typing import Iterable, Generator
 from spacy.tokens import Doc
+from spacy.tokens.underscore import Underscore
 from spacy.util import minibatch
 from medcat.ner.vocab_based_annotator import maybe_annotate_name
 
@@ -18,18 +19,22 @@ class NER(object):
         self.config = config
         self.cdb = cdb
 
-    def pipe(self, stream: Iterable[Doc], batch_size: int = 128) -> Generator[Doc, None, None]:
-        n_jobs = max(joblib.cpu_count() - 1, 1)
-        parallel = joblib.Parallel(n_jobs=n_jobs, backend="multiprocessing")
+    def pipe(self, stream: Iterable[Doc], batch_size: int = None, n_process: int = None) -> Generator[Doc, None, None]:
+        batch_size = self.config.ner['batch_size'] if batch_size is None else batch_size
+        n_process = self.config.ner['n_process'] if n_process is None else n_process
+        execute = joblib.Parallel(n_jobs=n_process)
         for docs in minibatch(stream, size=batch_size):
             try:
-                yield from parallel(joblib.delayed(self)(doc) for doc in docs)
+                run_pipe_on_one = joblib.delayed(NER._run_pipe_on_one)
+                tasks = (run_pipe_on_one(self, doc, Underscore.get_state()) for doc in docs)
+                yield from execute(tasks)
             except Exception as e:
                 self.log.warning(e, stack_info=True)
                 self.log.warning("Docs contained in the failed mini batch:")
                 for doc in docs:
                     if hasattr(doc, "text"):
                         self.log.warning("{}...".format(doc.text[:50]))
+                yield from docs
 
     def __call__(self, doc):
         r''' Detect candidates for concepts - linker will then be able to do the rest. It adds `entities` to the
@@ -96,3 +101,8 @@ class NER(object):
                         break
 
         return doc
+
+    @staticmethod
+    def _run_pipe_on_one(ner, doc, underscore_state):
+        Underscore.load_state(underscore_state)
+        return ner(doc)

--- a/medcat/pipe.py
+++ b/medcat/pipe.py
@@ -126,7 +126,7 @@ class Pipe(object):
 
     def batch_multi_process(self,
                             texts: Iterable[str],
-                            n_process: Optional[int] = None,
+                            n_process: Optional[int] = 1, # 1 because multiprocessing will be conducted inside pipeline components so as to work with multi-core GPUs.
                             batch_size: Optional[int] = None,
                             total: Optional[int] = None) -> Generator[Doc, None, None]:
         r''' Batch process a list of texts in parallel.

--- a/medcat/pipe.py
+++ b/medcat/pipe.py
@@ -163,16 +163,26 @@ class Pipe(object):
                                  batch_size=batch_size,
                                  component_cfg={
                                      NER.name: {
-                                         'n_process': n_process
+                                         'parallel': True
                                      },
                                      Linker.name: {
-                                         'n_process': n_process
+                                         'parallel': True
                                      }
                                  })
         else:
             # Multiprocessing will be conducted at the pipeline level.
-            # And texts will be processed sequentially inside components.
-            return self.nlp.pipe(texts if total is None else tqdm(texts, total=total), n_process=n_process, batch_size=batch_size)
+            # Then texts will be processed sequentially inside components.
+            return self.nlp.pipe(texts if total is None else tqdm(texts, total=total),
+                                 n_process=n_process,
+                                 batch_size=batch_size,
+                                 component_cfg={
+                                     NER.name: {
+                                         'parallel': False
+                                     },
+                                     Linker.name: {
+                                         'parallel': False
+                                     }
+                                 })
 
     def set_error_handler(self, error_handler):
         self.nlp.set_error_handler(error_handler)

--- a/medcat/pipeline/pipe_runner.py
+++ b/medcat/pipeline/pipe_runner.py
@@ -12,13 +12,12 @@ class PipeRunner(object):
     _execute = None
     _time_out_in_secs = 3600
 
-    def __init__(self, workers: int, batch_size: int):
-        self.batch_size = batch_size
+    def __init__(self, workers: int):
         PipeRunner._execute = Parallel(n_jobs=workers, timeout=PipeRunner._time_out_in_secs)
 
-    def pipe(self, stream: Iterable[Doc], **kwargs) -> Generator[Doc, None, None]:
+    def pipe(self, stream: Iterable[Doc], batch_size: int, **kwargs) -> Generator[Doc, None, None]:
         if kwargs.get("parallel", False):
-            for docs in minibatch(stream, size=self.batch_size):
+            for docs in minibatch(stream, size=batch_size):
                 try:
                     run_pipe_on_one = delayed(self._run_pipe_on_one)
                     tasks = (run_pipe_on_one(self, doc, Underscore.get_state()) for doc in docs)

--- a/medcat/pipeline/pipe_runner.py
+++ b/medcat/pipeline/pipe_runner.py
@@ -1,0 +1,46 @@
+import logging
+from joblib import Parallel, delayed
+from typing import Iterable, Generator, Tuple
+from spacy.tokens import Doc
+from spacy.tokens.underscore import Underscore
+from spacy.util import minibatch
+
+
+class PipeRunner(object):
+
+    log = logging.getLogger(__name__)
+    _execute = None
+    _time_out_in_secs = 3600
+
+    def __init__(self, workers: int, batch_size: int):
+        self.batch_size = batch_size
+        PipeRunner._execute = Parallel(n_jobs=workers, timeout=PipeRunner._time_out_in_secs)
+
+    def pipe(self, stream: Iterable[Doc], **kwargs) -> Generator[Doc, None, None]:
+        if kwargs.get("n_process") == 1:
+            # Multiprocessing will be conducted inside pipeline components so as to work with multi-core GPUs.
+            for docs in minibatch(stream, size=self.batch_size):
+                try:
+                    run_pipe_on_one = delayed(self._run_pipe_on_one)
+                    tasks = (run_pipe_on_one(self, doc, Underscore.get_state()) for doc in docs)
+                    yield from PipeRunner._execute(tasks)
+                except Exception as e:
+                    self.log.warning(e, stack_info=True)
+                    self.log.warning("Docs contained in the failed mini batch:")
+                    for doc in docs:
+                        if hasattr(doc, "text"):
+                            self.log.warning("{}...".format(doc.text[:50]))
+                    yield from docs
+        else:
+            # Multiprocessing will be conducted at the pipeline level.
+            # And texts will be processed sequentially inside components.
+            for doc in stream:
+                yield self(doc)
+
+    def __call__(self, doc: Doc) -> Doc:
+        raise NotImplementedError("__call__ is not implemented.")
+
+    @staticmethod
+    def _run_pipe_on_one(pipe_runner: "PipeRunner", doc: Doc, underscore_state: Tuple) -> "PipeRunner":
+        Underscore.load_state(underscore_state)
+        return pipe_runner(doc)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -68,9 +68,9 @@ class CATTests(unittest.TestCase):
         in_data = [
             (1, "The dog is sitting outside the house."),
             (2, "The dog is sitting outside the house."),
-            (3, "The dog is sitting outside the house.")
+            (3, "The dog is sitting outside the house."),
         ]
-        out = self.undertest.multiprocessing_pipe(in_data, nproc=2)
+        out = self.undertest.multiprocessing_pipe(in_data)
         self.assertTrue(type(out) == list)
         self.assertEqual(3, len(out))
         self.assertEqual(1, out[0][0])
@@ -86,7 +86,7 @@ class CATTests(unittest.TestCase):
             (2, "The dog is sitting outside the house."),
             (3, "The dog is sitting outside the house.")
         ]
-        out = self.undertest.multiprocessing_pipe(in_data, nproc=2, return_dict=True)
+        out = self.undertest.multiprocessing_pipe(in_data, return_dict=True)
         self.assertTrue(type(out) == dict)
         self.assertEqual(3, len(out))
         self.assertEqual({'entities': {}, 'tokens': [], 'text': "The dog is sitting outside the house."}, out[1])
@@ -106,7 +106,7 @@ class CATTests(unittest.TestCase):
 
     def test_get_entities_from_in_data(self):
         in_data = [(1, "The dog is sitting outside the house."), (2, ""), (3, "The dog is sitting outside the house.")]
-        out = self.undertest.get_entities(in_data, n_process=2)
+        out = self.undertest.get_entities(in_data, n_process=1)
         self.assertEqual(3, len(out))
 
     def test_train_supervised(self):
@@ -155,7 +155,7 @@ class CATTests(unittest.TestCase):
                                            (2, "The dog is sitting outside the house."),
                                            (3, "The dog is sitting outside the house."),
                                            (4, None),
-                                           (5, None)], n_process=2, batch_size=2)
+                                           (5, None)], n_process=1, batch_size=2)
         self.assertEqual(5, len(out))
         self.assertEqual({}, out[0]["entities"])
         self.assertEqual([], out[0]["tokens"])

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -87,7 +87,7 @@ class CATTests(unittest.TestCase):
             (2, "The dog is sitting outside the house."),
             (3, "The dog is sitting outside the house.")
         ]
-        out = self.undertest.multiprocessing_pipe(in_data, return_dict=True)
+        out = self.undertest.multiprocessing_pipe(in_data, nproc=2, return_dict=True)
         self.assertTrue(type(out) == dict)
         self.assertEqual(3, len(out))
         self.assertEqual({'entities': {}, 'tokens': [], 'text': "The dog is sitting outside the house."}, out[1])
@@ -107,7 +107,7 @@ class CATTests(unittest.TestCase):
 
     def test_get_entities_from_in_data(self):
         in_data = [(1, "The dog is sitting outside the house."), (2, ""), (3, "The dog is sitting outside the house.")]
-        out = self.undertest.get_entities(in_data, n_process=1)
+        out = self.undertest.get_entities(in_data, n_process=2)
         self.assertEqual(3, len(out))
 
     def test_train_supervised(self):

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -56,7 +56,6 @@ class CATTests(unittest.TestCase):
             (3, "The dog is sitting outside the house.")
         ]
         out = list(self.undertest.multiprocessing(in_data, nproc=1))
-        import pdb; pdb.set_trace()
         self.assertEqual(3, len(out))
         self.assertEqual(1, out[0][0])
         self.assertEqual("The dog is sitting outside the house.", out[0][1]["text"])
@@ -160,11 +159,19 @@ class CATTests(unittest.TestCase):
         self.assertEqual(5, len(out))
         self.assertEqual({}, out[0]["entities"])
         self.assertEqual([], out[0]["tokens"])
+        self.assertEqual("The dog is sitting outside the house.", out[0]["text"])
         self.assertEqual({}, out[1]["entities"])
         self.assertEqual([], out[1]["tokens"])
-        self.assertIsNone(out[2])
-        self.assertIsNone(out[3])
-        self.assertIsNone(out[4])
+        self.assertEqual("The dog is sitting outside the house.", out[1]["text"])
+        self.assertEqual({}, out[2]["entities"])
+        self.assertEqual([], out[2]["tokens"])
+        self.assertEqual("The dog is sitting outside the house.", out[2]["text"])
+        self.assertEqual({}, out[3]["entities"])
+        self.assertEqual([], out[3]["tokens"])
+        self.assertFalse(hasattr(out[2], "text"))
+        self.assertEqual({}, out[4]["entities"])
+        self.assertEqual([], out[4]["tokens"])
+        self.assertFalse(hasattr(out[4], "text"))
 
 
 if __name__ == '__main__':

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -5,6 +5,7 @@ from medcat.cdb import CDB
 from medcat.cat import CAT
 
 
+# TODO: add parameterised tests covering both n_process = 1 and > 1
 class CATTests(unittest.TestCase):
 
     @classmethod
@@ -155,7 +156,7 @@ class CATTests(unittest.TestCase):
                                            (2, "The dog is sitting outside the house."),
                                            (3, "The dog is sitting outside the house."),
                                            (4, None),
-                                           (5, None)], n_process=1, batch_size=2)
+                                           (5, None)], n_process=2, batch_size=2)
         self.assertEqual(5, len(out))
         self.assertEqual({}, out[0]["entities"])
         self.assertEqual([], out[0]["tokens"])

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -1,3 +1,8 @@
+import logging
+import os
+import requests
+import unittest
+from spacy.lang.en import English
 from medcat.preprocessing.tokenizers import spacy_split_all
 from medcat.ner.vocab_based_ner import NER
 from medcat.preprocessing.taggers import tag_skip_and_punct
@@ -7,12 +12,7 @@ from medcat.vocab import Vocab
 from medcat.preprocessing.cleaners import prepare_name
 from medcat.linking.context_based_linker import Linker
 from medcat.config import Config
-import logging
 from medcat.cdb import CDB
-import os
-import requests
-import unittest
-from spacy.lang.en import English
 
 
 class A_NERTests(unittest.TestCase):
@@ -98,6 +98,20 @@ class A_NERTests(unittest.TestCase):
         nlp = English()
 
         docs = list(self.ner.pipe([nlp.make_doc(self.text), nlp.make_doc(self.text), nlp.make_doc(self.text)]))
+
+        self.assertEqual(3, len(docs))
+        self.assertEqual(self.text, docs[0].text)
+        self.assertEqual(self.text, docs[1].text)
+        self.assertEqual(self.text, docs[2].text)
+
+    def test_pipe2(self):
+        nlp = English()
+        docs = [nlp.make_doc(self.text), nlp.make_doc(self.text), nlp.make_doc(self.text)]
+        for doc in docs:
+            for token in doc:
+                token._.to_skip = False
+
+        docs = list(self.link(docs))
 
         self.assertEqual(3, len(docs))
         self.assertEqual(self.text, docs[0].text)

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -12,6 +12,7 @@ from medcat.cdb import CDB
 import os
 import requests
 import unittest
+from spacy.lang.en import English
 
 
 class A_NERTests(unittest.TestCase):
@@ -34,19 +35,19 @@ class A_NERTests(unittest.TestCase):
 
 
         print("Set up NLP pipeline")
-        cls.nlp = Pipe(tokenizer=spacy_split_all, config=cls.config)
-        cls.nlp.add_tagger(tagger=tag_skip_and_punct,
-                       name='skip_and_punct',
-                       additional_fields=['is_punct'])
+        cls.pipe = Pipe(tokenizer=spacy_split_all, config=cls.config)
+        cls.pipe.add_tagger(tagger=tag_skip_and_punct,
+                            name='skip_and_punct',
+                            additional_fields=['is_punct'])
 
         cls.spell_checker = BasicSpellChecker(cdb_vocab=cls.cdb.vocab, config=cls.config, data_vocab=cls.vocab)
-        cls.nlp.add_token_normalizer(spell_checker=cls.spell_checker, config=cls.config)
+        cls.pipe.add_token_normalizer(spell_checker=cls.spell_checker, config=cls.config)
         cls.ner = NER(cls.cdb, cls.config)
-        cls.nlp.add_ner(cls.ner)
+        cls.pipe.add_ner(cls.ner)
 
         print("Set up Linker")
         cls.link = Linker(cls.cdb, cls.vocab, cls.config)
-        cls.nlp.add_linker(cls.link)
+        cls.pipe.add_linker(cls.link)
 
         print("Set limits for tokens and uppercase")
         cls.config.ner['max_skip_tokens'] = 1
@@ -55,17 +56,17 @@ class A_NERTests(unittest.TestCase):
         cls.config.general["spacy_model"] = "en_core_sci_sm"
 
         print("Add concepts")
-        cls.cdb.add_names(cui='S-229004', names=prepare_name('Movar', cls.nlp, {}, cls.config))
-        cls.cdb.add_names(cui='S-229004', names=prepare_name('Movar viruses', cls.nlp, {}, cls.config))
-        cls.cdb.add_names(cui='S-229005', names=prepare_name('CDB', cls.nlp, {}, cls.config))
+        cls.cdb.add_names(cui='S-229004', names=prepare_name('Movar', cls.pipe, {}, cls.config))
+        cls.cdb.add_names(cui='S-229004', names=prepare_name('Movar viruses', cls.pipe, {}, cls.config))
+        cls.cdb.add_names(cui='S-229005', names=prepare_name('CDB', cls.pipe, {}, cls.config))
 
         print("Add test text")
         cls.text = "CDB - I was running and then Movar    Virus attacked and CDb"
-        cls.text_post_pipe = cls.nlp(cls.text)
+        cls.text_post_pipe = cls.pipe(cls.text)
 
     @classmethod
     def tearDownClass(cls) -> None:
-        cls.nlp.destroy()
+        cls.pipe.destroy()
 
     def test_aa_cdb_names_output(self):
         target_result = {'S-229004': {'movar~virus', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}
@@ -80,19 +81,28 @@ class A_NERTests(unittest.TestCase):
 
     def test_ad_max_skip_entities_length(self):
         self.config.ner['max_skip_tokens'] = 3
-        self.text_post_pipe = self.nlp(self.text)
+        self.text_post_pipe = self.pipe(self.text)
         self.assertEqual(len(self.text_post_pipe._.ents), 3, "Should equal 3")
 
     def test_ae_upper_case_entities_length(self):
         self.config.ner['upper_case_limit_len'] = 3
-        self.text_post_pipe = self.nlp(self.text)
+        self.text_post_pipe = self.pipe(self.text)
         self.assertEqual(len(self.text_post_pipe._.ents), 4, "Should equal 4")
 
     def test_af_min_name_entities_length(self):
         self.config.ner['min_name_len'] = 4
-        self.text_post_pipe = self.nlp(self.text)
+        self.text_post_pipe = self.pipe(self.text)
         self.assertEqual(len(self.text_post_pipe._.ents), 2, "Should equal 2")
 
+    def test_pipe(self):
+        nlp = English()
+
+        docs = list(self.ner.pipe([nlp.make_doc(self.text), nlp.make_doc(self.text), nlp.make_doc(self.text)]))
+
+        self.assertEqual(3, len(docs))
+        self.assertEqual(self.text, docs[0].text)
+        self.assertEqual(self.text, docs[1].text)
+        self.assertEqual(self.text, docs[2].text)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -94,29 +94,6 @@ class A_NERTests(unittest.TestCase):
         self.text_post_pipe = self.pipe(self.text)
         self.assertEqual(len(self.text_post_pipe._.ents), 2, "Should equal 2")
 
-    def test_pipe(self):
-        nlp = English()
-
-        docs = list(self.ner.pipe([nlp.make_doc(self.text), nlp.make_doc(self.text), nlp.make_doc(self.text)]))
-
-        self.assertEqual(3, len(docs))
-        self.assertEqual(self.text, docs[0].text)
-        self.assertEqual(self.text, docs[1].text)
-        self.assertEqual(self.text, docs[2].text)
-
-    def test_pipe2(self):
-        nlp = English()
-        docs = [nlp.make_doc(self.text), nlp.make_doc(self.text), nlp.make_doc(self.text)]
-        for doc in docs:
-            for token in doc:
-                token._.to_skip = False
-
-        docs = list(self.link(docs))
-
-        self.assertEqual(3, len(docs))
-        self.assertEqual(self.text, docs[0].text)
-        self.assertEqual(self.text, docs[1].text)
-        self.assertEqual(self.text, docs[2].text)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -87,12 +87,30 @@ class PipeTests(unittest.TestCase):
         PipeTests.undertest.add_meta_cat(PipeTests.meta_cat)
 
         PipeTests.undertest.set_error_handler(_error_handler)
-        docs = list(self.undertest.batch_multi_process([PipeTests.text, None, PipeTests.text], n_process=2, batch_size=1))
+        docs = list(self.undertest.batch_multi_process([PipeTests.text, PipeTests.text, PipeTests.text], n_process=2, batch_size=1))
         PipeTests.undertest.reset_error_handler()
 
-        self.assertEqual(2, len(docs))
+        self.assertEqual(3, len(docs))
         self.assertEqual(PipeTests.text, docs[0].text)
         self.assertEqual(PipeTests.text, docs[1].text)
+        self.assertEqual(PipeTests.text, docs[2].text)
+
+    def test_callable_with_generated_texts(self):
+        def _generate_texts(texts):
+            yield from texts
+
+        PipeTests.undertest.add_tagger(tagger=tag_skip_and_punct, additional_fields=["is_punct"])
+        PipeTests.undertest.add_token_normalizer(PipeTests.config, spell_checker=PipeTests.spell_checker)
+        PipeTests.undertest.add_ner(PipeTests.ner)
+        PipeTests.undertest.add_linker(PipeTests.linker)
+        PipeTests.undertest.add_meta_cat(PipeTests.meta_cat)
+
+        docs = list(self.undertest(_generate_texts([PipeTests.text, None, PipeTests.text])))
+
+        self.assertEqual(3, len(docs))
+        self.assertEqual(PipeTests.text, docs[0].text)
+        self.assertIsNone(docs[1])
+        self.assertEqual(PipeTests.text, docs[2].text)
 
     def test_callable_with_single_text(self):
         PipeTests.undertest.add_tagger(tagger=tag_skip_and_punct, additional_fields=["is_punct"])
@@ -113,23 +131,6 @@ class PipeTests(unittest.TestCase):
         PipeTests.undertest.add_meta_cat(PipeTests.meta_cat)
 
         docs = list(self.undertest([PipeTests.text, None, PipeTests.text]))
-
-        self.assertEqual(3, len(docs))
-        self.assertEqual(PipeTests.text, docs[0].text)
-        self.assertIsNone(docs[1])
-        self.assertEqual(PipeTests.text, docs[2].text)
-
-    def test_callable_with_generated_texts(self):
-        def _generate_texts(texts):
-            yield from texts
-
-        PipeTests.undertest.add_tagger(tagger=tag_skip_and_punct, additional_fields=["is_punct"])
-        PipeTests.undertest.add_token_normalizer(PipeTests.config, spell_checker=PipeTests.spell_checker)
-        PipeTests.undertest.add_ner(PipeTests.ner)
-        PipeTests.undertest.add_linker(PipeTests.linker)
-        PipeTests.undertest.add_meta_cat(PipeTests.meta_cat)
-
-        docs = list(self.undertest(_generate_texts([PipeTests.text, None, PipeTests.text])))
 
         self.assertEqual(3, len(docs))
         self.assertEqual(PipeTests.text, docs[0].text)

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -87,12 +87,13 @@ class PipeTests(unittest.TestCase):
         PipeTests.undertest.add_meta_cat(PipeTests.meta_cat)
 
         PipeTests.undertest.set_error_handler(_error_handler)
-        docs = list(self.undertest.batch_multi_process([PipeTests.text, None, PipeTests.text], n_process=2, batch_size=1))
+        docs = list(self.undertest.batch_multi_process([PipeTests.text, PipeTests.text, PipeTests.text], n_process=1, batch_size=1))
         PipeTests.undertest.reset_error_handler()
 
-        self.assertEqual(2, len(docs))
+        self.assertEqual(3, len(docs))
         self.assertEqual(PipeTests.text, docs[0].text)
         self.assertEqual(PipeTests.text, docs[1].text)
+        self.assertEqual(PipeTests.text, docs[2].text)
 
     def test_callable_with_generated_texts(self):
         def _generate_texts(texts):

--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -87,13 +87,12 @@ class PipeTests(unittest.TestCase):
         PipeTests.undertest.add_meta_cat(PipeTests.meta_cat)
 
         PipeTests.undertest.set_error_handler(_error_handler)
-        docs = list(self.undertest.batch_multi_process([PipeTests.text, PipeTests.text, PipeTests.text], n_process=2, batch_size=1))
+        docs = list(self.undertest.batch_multi_process([PipeTests.text, None, PipeTests.text], n_process=2, batch_size=1))
         PipeTests.undertest.reset_error_handler()
 
-        self.assertEqual(3, len(docs))
+        self.assertEqual(2, len(docs))
         self.assertEqual(PipeTests.text, docs[0].text)
         self.assertEqual(PipeTests.text, docs[1].text)
-        self.assertEqual(PipeTests.text, docs[2].text)
 
     def test_callable_with_generated_texts(self):
         def _generate_texts(texts):

--- a/tests/test_pipe_runner.py
+++ b/tests/test_pipe_runner.py
@@ -11,8 +11,9 @@ class PipeRunnerTests(unittest.TestCase):
         cls.nlp = English()
 
     def test_pipe_single_process_multi_workers(self):
-        docs = list(_PipeRunnerImpl(workers=2, batch_size=1).pipe(
+        docs = list(_PipeRunnerImpl(workers=2).pipe(
             [self.nlp.make_doc(self.text), self.nlp.make_doc(self.text), self.nlp.make_doc(self.text)],
+            batch_size=1,
             parallel=True
         ))
 
@@ -22,8 +23,9 @@ class PipeRunnerTests(unittest.TestCase):
         self.assertEqual(self.text, docs[2].text)
 
     def test_pipe_multi_processes_single_work(self):
-        docs = list(_PipeRunnerImpl(workers=1, batch_size=1).pipe(
+        docs = list(_PipeRunnerImpl(workers=1).pipe(
             [self.nlp.make_doc(self.text), self.nlp.make_doc(self.text), self.nlp.make_doc(self.text)],
+            batch_size=1,
             parallel=False
         ))
 
@@ -33,8 +35,9 @@ class PipeRunnerTests(unittest.TestCase):
         self.assertEqual(self.text, docs[2].text)
 
     def test_pipe_multi_processes_multi_workers(self):
-        docs = list(_PipeRunnerImpl(workers=2, batch_size=1).pipe(
+        docs = list(_PipeRunnerImpl(workers=2).pipe(
             [self.nlp.make_doc(self.text), self.nlp.make_doc(self.text), self.nlp.make_doc(self.text)],
+            batch_size=1,
             parallel=True
         ))
 

--- a/tests/test_pipe_runner.py
+++ b/tests/test_pipe_runner.py
@@ -1,0 +1,40 @@
+import unittest
+from spacy.lang.en import English
+from medcat.pipeline.pipe_runner import PipeRunner
+
+
+class PipeRunnerTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = "CDB - I was running and then Movar Virus attacked and CDb"
+        cls.nlp = English()
+
+    def test_pipe_single_process_multi_workers(self):
+        docs = list(_PipeRunnerImpl(workers=2, batch_size=1).pipe(
+            [self.nlp.make_doc(self.text), self.nlp.make_doc(self.text), self.nlp.make_doc(self.text)],
+            n_process=1
+        ))
+
+        self.assertEqual(3, len(docs))
+        self.assertEqual(self.text, docs[0].text)
+        self.assertEqual(self.text, docs[1].text)
+        self.assertEqual(self.text, docs[2].text)
+
+    def test_pipe_multi_processes_single_work(self):
+        docs = list(_PipeRunnerImpl(workers=1, batch_size=1).pipe(
+            [self.nlp.make_doc(self.text), self.nlp.make_doc(self.text), self.nlp.make_doc(self.text)],
+            n_process=2
+        ))
+
+        self.assertEqual(3, len(docs))
+        self.assertEqual(self.text, docs[0].text)
+        self.assertEqual(self.text, docs[1].text)
+        self.assertEqual(self.text, docs[2].text)
+
+
+class _PipeRunnerImpl(PipeRunner):
+
+    def __call__(self, doc):
+        return doc
+

--- a/tests/test_pipe_runner.py
+++ b/tests/test_pipe_runner.py
@@ -13,7 +13,7 @@ class PipeRunnerTests(unittest.TestCase):
     def test_pipe_single_process_multi_workers(self):
         docs = list(_PipeRunnerImpl(workers=2, batch_size=1).pipe(
             [self.nlp.make_doc(self.text), self.nlp.make_doc(self.text), self.nlp.make_doc(self.text)],
-            n_process=1
+            parallel=True
         ))
 
         self.assertEqual(3, len(docs))
@@ -24,7 +24,18 @@ class PipeRunnerTests(unittest.TestCase):
     def test_pipe_multi_processes_single_work(self):
         docs = list(_PipeRunnerImpl(workers=1, batch_size=1).pipe(
             [self.nlp.make_doc(self.text), self.nlp.make_doc(self.text), self.nlp.make_doc(self.text)],
-            n_process=2
+            parallel=False
+        ))
+
+        self.assertEqual(3, len(docs))
+        self.assertEqual(self.text, docs[0].text)
+        self.assertEqual(self.text, docs[1].text)
+        self.assertEqual(self.text, docs[2].text)
+
+    def test_pipe_multi_processes_multi_workers(self):
+        docs = list(_PipeRunnerImpl(workers=2, batch_size=1).pipe(
+            [self.nlp.make_doc(self.text), self.nlp.make_doc(self.text), self.nlp.make_doc(self.text)],
+            parallel=True
         ))
 
         self.assertEqual(3, len(docs))


### PR DESCRIPTION
Enable `cat.mutiprocessing_pipe()` to process docs in either the parallel or the sequential manner.