### PR TITLE
Add functionality to process diacritics

### DIFF
--- a/medcat/config.py
+++ b/medcat/config.py
@@ -168,6 +168,9 @@ class Config(BaseConfig):
                 # Should we check spelling - note that this makes things much slower, use only if necessary. The only thing necessary
                 #for the spell checker to work is vocab.dat and cdb.dat built with concepts in the respective language.
                 'spell_check': True,
+                # Should we process diacritics - for languages other than English, symbols such as 'é, ë, ö' can be relevant.
+                # Note that this makes spell_check slower.
+                'diacritics': False,
                 # If True the spell checker will try harder to find mistakes, this can slow down
                 #things drastically.
                 'spell_check_deep': False,

--- a/medcat/pipe.py
+++ b/medcat/pipe.py
@@ -39,7 +39,7 @@ class Pipe(object):
         self.nlp = spacy.load(config.general['spacy_model'], disable=config.general['spacy_disabled_components'])
         if config.preprocessing['stopwords'] is not None:
             self.nlp.Defaults.stop_words = set(config.preprocessing['stopwords'])
-        self.nlp.tokenizer = tokenizer(self.nlp)
+        self.nlp.tokenizer = tokenizer(self.nlp, config)
         self.config = config
         # Set log level
         self.log.setLevel(self.config.general['log_level'])

--- a/medcat/preprocessing/tokenizers.py
+++ b/medcat/preprocessing/tokenizers.py
@@ -29,10 +29,16 @@ def spacy_extended(nlp):
             )
 
 
-def spacy_split_all(nlp):
-    infix_re = re.compile(r'''[^A-Za-z0-9\@]''')
-    suffix_re = re.compile(r'''[^A-Za-z0-9\@]$''')
-    prefix_re = re.compile(r'''^[^A-Za-z0-9\@]''')
+def spacy_split_all(nlp, config):
+
+    token_characters = r'[^A-Za-z0-9\@]'
+
+    if config.general['diacritics']:
+        token_characters = r'[^A-Za-zÀ-ÖØ-öø-ÿ0-9\@]'
+
+    infix_re = re.compile(token_characters)
+    suffix_re = re.compile(token_characters + r'$')
+    prefix_re = re.compile(r'^' + token_characters)
     return Tokenizer(nlp.vocab,
             rules={},
             token_match=None,

--- a/medcat/utils/normalizers.py
+++ b/medcat/utils/normalizers.py
@@ -63,7 +63,7 @@ class BasicSpellChecker(object):
         letters    = 'abcdefghijklmnopqrstuvwxyz'
 
         if self.config.general['diacritics']:
-            letters += 'àáâãäåæçèéêëìíîï00F0ðñòóôõöøùúûüýþÿ'
+            letters += 'àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ'
 
         splits     = [(word[:i], word[i:])    for i in range(len(word) + 1)]
         deletes    = [L + R[1:]               for L, R in splits if R]

--- a/medcat/utils/normalizers.py
+++ b/medcat/utils/normalizers.py
@@ -61,6 +61,10 @@ class BasicSpellChecker(object):
     def edits1(self, word):
         "All edits that are one edit away from `word`."
         letters    = 'abcdefghijklmnopqrstuvwxyz'
+
+        if self.config.general['diacritics']:
+            letters += 'àáâãäåæçèéêëìíîï00F0ðñòóôõöøùúûüýþÿ'
+
         splits     = [(word[:i], word[i:])    for i in range(len(word) + 1)]
         deletes    = [L + R[1:]               for L, R in splits if R]
         transposes = [L + R[1] + R[0] + R[2:] for L, R in splits if len(R)>1]


### PR DESCRIPTION
#117 

These changes enable processing of diacritics in spell checking and cdb maker. For e.g.: a word such as "hyponatriëmie" used to be processsed into "hyponatri~mie", but will now be handled correctly. We tested this on entity linking and it is working correctly.

Together with @sandertan 