### PR TITLE
Improve NER of uppercase tokens

### DIFF
--- a/medcat/config.py
+++ b/medcat/config.py
@@ -180,8 +180,6 @@ class Config(BaseConfig):
                 'show_nested_entities': False,
                 # When unlinking a name from a concept should we do full_unlink (means unlink a name from all concepts, not just the one in question)
                 'full_unlink': False,
-                # Additional checking whether the concepts are uppercase or not before linking concepts
-                'check_upper_case_names': False,
                 # Number of workers used by a parallelizable pipeline component
                 'workers': workers(),
                 # Should the labels of entities (shown in displacy) be pretty or just 'concept'. Slows down the annotation pipeline
@@ -213,6 +211,8 @@ class Config(BaseConfig):
                 # When checkng tokens for concepts you can have skipped tokens inbetween
                 #used ones (usually spaces, new lines etc). This number tells you how many skipped can you have.
                 'max_skip_tokens': 2,
+                # Check uppercase to distinguish uppercase and lowercase words that have a different meaning.
+                'check_upper_case_names': False,
                 # Any name shorter than this must be uppercase in the text to be considered. If it is not uppercase
                 #it will be skipped.
                 'upper_case_limit_len': 3,


### PR DESCRIPTION
Hi @w-is-h , we noticed that sometimes clinical text contains tokens in uppercase that are semantically identical to a lowercase name in CDB. For example, CDB contains "taxotere", while text is:
> After TAXOTERE treatment

Our previous implementation `check_upper_case_names` recognized this as mismatch, and terminated NER (`return None`) for that token.

In this PR I:
- Solved the above issue by only terminating NER when the CDB name is in uppercase and the token is lowercase. For example to distinguish the concept `MAP` (C0026045) from the lowercase word `map`.
- Simplified this logic by separating it from the next if-statements
- Did not change the next if-statements except for changing the indention.
- Moved the property for `check_upper_case_names` from `config.general` to `config.ner`.

We tested this in internal unit tests, and it now works as expected. In a future PR I'd like to include these tests in this repo.