### PR TITLE
Fix pipeline for creating vocab with gensim 4.1.2

### DIFF
--- a/medcat/preprocessing/tokenizers.py
+++ b/medcat/preprocessing/tokenizers.py
@@ -114,7 +114,7 @@ class SpacyHFTok(object):
         self.nlp = spacy.load('en_core_sci_md', disable=['ner', 'parser'])
         self.emb_map = {}
         self.embs = []
-        for key in w2v.wv.vocab.keys():
+        for key in w2v.wv.key_to_index.keys():
             self.emb_map[key] = len(self.embs)
             self.embs.append(w2v[key])
 

--- a/medcat/utils/make_vocab.py
+++ b/medcat/utils/make_vocab.py
@@ -120,7 +120,7 @@ class MakeVocab(object):
         self.vocab.save(path=self.vocab_path)
 
 
-    def add_vectors(self, in_path=None, w2v=None, overwrite=False, data_iter=None, workers=14, niter=2, min_count=10, window=10, vsize=300,
+    def add_vectors(self, in_path=None, w2v=None, overwrite=False, data_iter=None, workers=14, epochs=2, min_count=10, window=10, vector_size=300,
                     unigram_table_size=100000000):
         r'''
         Add vectors to an existing vocabulary and save changes to the vocab_path.
@@ -144,9 +144,9 @@ class MakeVocab(object):
                 data = SimpleIter(in_path)
             else:
                 data = data_iter
-            w2v = Word2Vec(data, window=window, min_count=min_count, workers=workers, size=vsize, iter=niter)
+            w2v = Word2Vec(data, window=window, min_count=min_count, workers=workers, vector_size=vector_size, epochs=epochs)
 
-        for word in w2v.wv.vocab.keys():
+        for word in w2v.wv.key_to_index.keys():
             if word in self.vocab:
                 if overwrite:
                     self.vocab.add_vec(word, w2v.wv.get_vector(word))


### PR DESCRIPTION
Hi @w-is-h , gensim 4.1.2 in MedCAT 1.2.0 introduced some changes to the `Word2Vec()` class which caused MedCAT to crash during creation of the vocabulary. Our medcat-model-creator integration test picked this up. I'll try to create a separate PR to port this creator & tests to MedCAT next week, as discussed in #116 

I renamed the parameters in `add_vectors()` to match the names in `Word2Vec`. Let me know if you'd like to keep the old MedCAT names.

### Changes in Word2Vec
```bash
  File "/Users/stan3/Data/MedCAT/medcat/utils/make_vocab.py", line 149, in add_vectors
    for word in w2v.wv.vocab.keys():
  File "/Users/stan3/miniconda3/envs/medcat-1-2-0/lib/python3.8/site-packages/gensim/models/keyedvectors.py", line 661, in vocab
    raise AttributeError(
AttributeError: The vocab attribute was removed from KeyedVector in Gensim 4.0.0.
Use KeyedVector's .key_to_index dict, .index_to_key list, and methods .get_vecattr(key, attr) and .set_vecattr(key, attr, new_val) instead.
See https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4
```

Also see: 
https://github.com/RaRe-Technologies/gensim/blob/5bec27767ad40712e8912d53a896cb2282c33880/gensim/models/word2vec.py#L322

and:
https://github.com/RaRe-Technologies/gensim/blob/5bec27767ad40712e8912d53a896cb2282c33880/gensim/models/word2vec.py#L273

