### PR TITLE
Change entities in output from dict to list

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -1160,7 +1160,7 @@ class CAT(object):
                     only_cui: bool,
                     addl_info: List[str],
                     out_with_text: bool = False) -> Dict:
-        out: Dict = {'entities': {}, 'tokens': []}
+        out: Dict = {'entities': [], 'tokens': []}
         cnf_annotation_output = getattr(self.config, 'annotation_output', {})
         if doc is not None:
             out_ent: Dict = {}
@@ -1222,9 +1222,9 @@ class CAT(object):
                     if hasattr(ent._, 'meta_anns') and ent._.meta_anns:
                         out_ent['meta_anns'] = ent._.meta_anns
 
-                    out['entities'][out_ent['id']] = dict(out_ent)
+                    out['entities'].append(dict(out_ent))
                 else:
-                    out['entities'][ent._.id] = cui
+                    out['entities'].append(cui)
 
             if cnf_annotation_output.get('include_text_in_output', False) or out_with_text:
                 out['text'] = doc.text

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -66,9 +66,9 @@ class CATTests(unittest.TestCase):
         self.assertEqual(1, out[0][0])
         self.assertEqual('second csv', out[0][1]['entities'][0]['source_value'])
         self.assertEqual(2, out[1][0])
-        self.assertEqual({'entities': {}, 'tokens': []}, out[1][1])
+        self.assertEqual({'entities': [], 'tokens': []}, out[1][1])
         self.assertEqual(3, out[2][0])
-        self.assertEqual({'entities': {}, 'tokens': []}, out[2][1])
+        self.assertEqual({'entities': [], 'tokens': []}, out[2][1])
 
     def test_multiprocessing_pipe_with_malformed_texts(self):
         in_data = [
@@ -80,11 +80,11 @@ class CATTests(unittest.TestCase):
         self.assertTrue(type(out) == list)
         self.assertEqual(3, len(out))
         self.assertEqual(1, out[0][0])
-        self.assertEqual({'entities': {}, 'tokens': []}, out[0][1])
+        self.assertEqual({'entities': [], 'tokens': []}, out[0][1])
         self.assertEqual(2, out[1][0])
-        self.assertEqual({'entities': {}, 'tokens': []}, out[1][1])
+        self.assertEqual({'entities': [], 'tokens': []}, out[1][1])
         self.assertEqual(3, out[2][0])
-        self.assertEqual({'entities': {}, 'tokens': []}, out[2][1])
+        self.assertEqual({'entities': [], 'tokens': []}, out[2][1])
 
     def test_multiprocessing_pipe_return_dict(self):
         in_data = [
@@ -95,9 +95,9 @@ class CATTests(unittest.TestCase):
         out = self.undertest.multiprocessing_pipe(in_data, nproc=2, return_dict=True)
         self.assertTrue(type(out) == dict)
         self.assertEqual(3, len(out))
-        self.assertEqual({'entities': {}, 'tokens': []}, out[1])
-        self.assertEqual({'entities': {}, 'tokens': []}, out[2])
-        self.assertEqual({'entities': {}, 'tokens': []}, out[3])
+        self.assertEqual({'entities': [], 'tokens': []}, out[1])
+        self.assertEqual({'entities': [], 'tokens': []}, out[2])
+        self.assertEqual({'entities': [], 'tokens': []}, out[3])
 
     def test_train(self):
         self.undertest.cdb.print_stats()
@@ -107,7 +107,7 @@ class CATTests(unittest.TestCase):
     def test_get_entities(self):
         text = "The dog is sitting outside the house."
         out = self.undertest.get_entities(text)
-        self.assertEqual({}, out["entities"])
+        self.assertEqual([], out["entities"])
         self.assertEqual([], out["tokens"])
         self.assertFalse("text" in out)
 
@@ -115,7 +115,7 @@ class CATTests(unittest.TestCase):
         self.cdb.config.annotation_output['include_text_in_output'] = True
         text = "The dog is sitting outside the house."
         out = self.undertest.get_entities(text)
-        self.assertEqual({}, out["entities"])
+        self.assertEqual([], out["entities"])
         self.assertEqual([], out["tokens"])
         self.assertTrue(text in out["text"])
 
@@ -149,32 +149,32 @@ class CATTests(unittest.TestCase):
 
     def test_no_error_handling_on_none_input(self):
         out = self.undertest.get_entities(None)
-        self.assertEqual({}, out["entities"])
+        self.assertEqual([], out["entities"])
         self.assertEqual([], out["tokens"])
 
     def test_no_error_handling_on_empty_string_input(self):
         out = self.undertest.get_entities("")
-        self.assertEqual({}, out["entities"])
+        self.assertEqual([], out["entities"])
         self.assertEqual([], out["tokens"])
 
     def test_no_raise_on_single_process_with_none(self):
         out = self.undertest.get_entities_multi_texts(["The dog is sitting outside the house.", None, "The dog is sitting outside the house."], n_process=1, batch_size=2)
         self.assertEqual(3, len(out))
-        self.assertEqual({}, out[0]["entities"])
+        self.assertEqual([], out[0]["entities"])
         self.assertEqual([], out[0]["tokens"])
-        self.assertEqual({}, out[1]["entities"])
+        self.assertEqual([], out[1]["entities"])
         self.assertEqual([], out[1]["tokens"])
-        self.assertEqual({}, out[2]["entities"])
+        self.assertEqual([], out[2]["entities"])
         self.assertEqual([], out[2]["tokens"])
 
     def test_no_raise_on_single_process_with_empty_string(self):
         out = self.undertest.get_entities_multi_texts(["The dog is sitting outside the house.", "", "The dog is sitting outside the house."], n_process=1, batch_size=2)
         self.assertEqual(3, len(out))
-        self.assertEqual({}, out[0]["entities"])
+        self.assertEqual([], out[0]["entities"])
         self.assertEqual([], out[0]["tokens"])
-        self.assertEqual({}, out[1]["entities"])
+        self.assertEqual([], out[1]["entities"])
         self.assertEqual([], out[1]["tokens"])
-        self.assertEqual({}, out[2]["entities"])
+        self.assertEqual([], out[2]["entities"])
         self.assertEqual([], out[2]["tokens"])
 
     def test_error_handling_multi_processes(self):
@@ -186,19 +186,19 @@ class CATTests(unittest.TestCase):
                                            (4, None),
                                            (5, None)], n_process=2, batch_size=2)
         self.assertEqual(5, len(out))
-        self.assertEqual({}, out[0]["entities"])
+        self.assertEqual([], out[0]["entities"])
         self.assertEqual([], out[0]["tokens"])
         self.assertTrue("The dog is sitting outside the house 1.", out[0]["text"])
-        self.assertEqual({}, out[1]["entities"])
+        self.assertEqual([], out[1]["entities"])
         self.assertEqual([], out[1]["tokens"])
         self.assertTrue("The dog is sitting outside the house 2.", out[1]["text"])
-        self.assertEqual({}, out[2]["entities"])
+        self.assertEqual([], out[2]["entities"])
         self.assertEqual([], out[2]["tokens"])
         self.assertTrue("The dog is sitting outside the house 3.", out[2]["text"])
-        self.assertEqual({}, out[3]["entities"])
+        self.assertEqual([], out[3]["entities"])
         self.assertEqual([], out[3]["tokens"])
         self.assertFalse("text" in out[3])
-        self.assertEqual({}, out[4]["entities"])
+        self.assertEqual([], out[4]["entities"])
         self.assertEqual([], out[4]["tokens"])
         self.assertFalse("text" in out[4])
 


### PR DESCRIPTION
Hi @w-is-h, these are the changes to solve  https://github.com/CogStack/MedCATservice/issues/20.

While searching for other usages, I noticed an independent section of code which uses similarly formatted data that assumes the `entities: dict()` format but is also compatible with the current MCT format `annotations: list()` (which is similar to format `entities: list()` I'm implementing here):
https://github.com/CogStack/MedCAT/blob/50509877b244a624d04758a37259f17fdac1e92d/medcat/utils/meta_cat/data_utils.py#L41 

It uses a MCT export (https://github.com/CogStack/MedCAT/blob/master/tests/resources/mct_export_for_meta_cat_test.json) which is different from the current MCT master format (https://github.com/CogStack/MedCAT/blob/master/tests/resources/medcat_trainer_export.json):


What's the plan with for this different MCT format? You might have guessed I like the current master MCT format ;)