### PR TITLE
Pin down the version of blis

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -966,7 +966,7 @@ class CAT(object):
                     for i, text in enumerate(texts_):
                         if i == len(out):
                             out.append(self._doc_to_out(None, only_cui, addl_info))
-                        elif out[i].get('text') != text:
+                        elif out[i].get('text', '') != text:
                             out.insert(i, self._doc_to_out(None, only_cui, addl_info))
 
                 cnf_annotation_output = getattr(self.config, 'annotation_output', {})

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setuptools.setup(
         'py2neo==2021.2.3',
         'aiofiles~=0.8.0',
         'ipywidgets~=7.6.5',
-        'xxhash==2.0.2'
+        'xxhash==2.0.2',
+        'blis==0.7.5',
         ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -284,8 +284,9 @@ class CATTests(unittest.TestCase):
                                            (1, "The dog is sitting outside the house 1."),
                                            (2, "The dog is sitting outside the house 2."),
                                            (3, "The dog is sitting outside the house 3."),
-                                           (4, None)], n_process=2, batch_size=2)
-        self.assertEqual(4, len(out))
+                                           (4, None),
+                                           (5, None)], n_process=2, batch_size=2)
+        self.assertEqual(5, len(out))
         self.assertEqual({}, out[0]["entities"])
         self.assertEqual([], out[0]["tokens"])
         self.assertTrue("The dog is sitting outside the house 1.", out[0]["text"])
@@ -298,6 +299,9 @@ class CATTests(unittest.TestCase):
         self.assertEqual({}, out[3]["entities"])
         self.assertEqual([], out[3]["tokens"])
         self.assertFalse("text" in out[3])
+        self.assertEqual({}, out[4]["entities"])
+        self.assertEqual([], out[4]["tokens"])
+        self.assertFalse("text" in out[4])
 
     def test_create_model_pack(self):
         save_dir_path = tempfile.TemporaryDirectory()


### PR DESCRIPTION

Merging https://github.com/CogStack/MedCAT/pull/207 from dependbot failed the CI with the error `ValueError: Shape mismatch for blis.gemm: (0, 0), (480, 288)`. See in:
https://github.com/CogStack/MedCAT/runs/5216493035?check_suite_focus=true#step:7:427

It was caused by the transitive `blis` being accidentally upgraded to 0.7.6 and spaCy has confirmed the bug in https://github.com/explosion/spaCy/issues/10334

This PR has temporarily pinned down the version of `blis` to 0.7.5 until spaCy can be upgraded with the fix. 