### PR TITLE
Stopping cat._print_stats() from over writing linking filters. 

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -373,7 +373,8 @@ class CAT(object):
 
         fp_docs: Set = set()
         fn_docs: Set = set()
-        # Reset and shortcut for filters
+        # reset and back up filters
+        _filters = deepcopy(self.config.linking['filters'])
         filters = self.config.linking['filters']
         for pind, project in tqdm(enumerate(data['projects']), desc="Stats project", total=len(data['projects']), leave=False):
             filters['cuis'] = set()
@@ -532,6 +533,9 @@ class CAT(object):
 
         except Exception:
             traceback.print_exc()
+
+        # restore filters to original state
+        self.config.linking['filters'] = _filters
 
         return fps, fns, tps, cui_prec, cui_rec, cui_f1, cui_counts, examples
 


### PR DESCRIPTION
Hi,

We were having trouble with the CUI filters in `config.linking['filters']` disappearing after `cat.train_supervised()` was called.

Presumably this isn't expected behaviour? It has been quite annoying because we would like our filters to persist even after printing stats in supervised training. 

The following code I have made up to reveal the problem.

```
from medcat.cat import CAT
from medcat.cdb import CDB
from medcat.vocab import Vocab

cdb_file = 'your_cdb.dat'
vocab_file = 'your_vocab.dat'
annotated_files = 'our_files.json' # our annotated training data

def train(print_=False):

	res = {}
	cdb = CDB.load(cdb_file)
	# recording len of filters pre training
	res['pre_train_len_cdb'] = len(cdb.config.linking['filters']['cuis'])
	vocab = Vocab.load(vocab_file)
	cat = CAT(cdb=cdb, config=cdb.config, vocab=vocab)
	 # recording len of filters as stored in the cat class pre training
	res['pre_train_len_cat'] = len(cat.config.linking['filters']['cuis'])

	cat.train_supervised(
		    data_path=annotated_files, nepochs=3, reset_cui_count=False, print_stats=False, use_filters=True
	)
	if print_:
	  logger.info(cat._print_stats(json.load(open(annotated_files)))

	res['post_train_len_cdb'] = len(cdb.config.linking['filters']['cuis'])
	res['post_train_len_cat'] = len(cat.config.linking['filters']['cuis'])

	return res


results = {}
results['not_print_stats'] = train()
results['with_print_stats'] = train(print_=True)
print(results)

```

The results dict (for us) looks like this:

` {'not_print_stats': {'pre_train_len_cdb':3000, 'pre_train_len_cat': 3000, 'post_train_len_cdb': 3000, 'post_train_len_cat': 3000}, 'with_print_stats': {'pre_train_len_cdb': 3000, 'pre_train_len_cat': 3000, 'post_train_len_cdb': 0, 'post_train_len_cat': 0}}`

n.b. I have replaced our own number for CUIs with 3000, just for privacy's sake

Clearly, as you can see, the call to _print_stats overwrites config.linking['filters']. In the post train filters, there are no CUIs. 

To fix this, I have just copied self.config.linking['filters'] in the same way that is done in cat.train_supervised().

Thanks for reading, and thanks for maintaining this code!

Will