### PR TITLE
fix create_model_pack to work with ~ directory

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -201,7 +201,8 @@ class CAT(object):
         _save_dir_path = save_dir_path
         save_dir_path = os.path.join(save_dir_path, model_pack_name)
 
-        os.makedirs(save_dir_path, exist_ok=True)
+        # expand user path to make this work with '~'
+        os.makedirs(os.path.expanduser(save_dir_path), exist_ok=True)
 
         # Save the used spacy model
         spacy_path = os.path.join(save_dir_path, self.config.general['spacy_model'])


### PR DESCRIPTION
- fixed the create_model_pack function to work with saving the model pack at paths starting with ~ by adding `expanduser` from `os.path`. It will leave the path unchanged if either no home directory was found or the path does not start with `~`.

- altough I thought adding `pathlib` (#237) would be beneficial here, I decided to go with `os.path` instead. Reasons being:
1. even with `pathlib` one would have to use `expanduser()`
2. Since the whole project already uses `os.path` I did not want to add a new "dependency" (even though its included in the standard library)

Any comments appreciated ;).