### PR TITLE
Update model creator

### DIFF
--- a/medcat/config.py
+++ b/medcat/config.py
@@ -219,6 +219,9 @@ class Config(ConfigMixin):
                 # Documents longer  than this will be trimmed
                 'max_document_length': 1000000,
                 # Should specific word types be normalized: e.g. running -> run
+                # Values are detailed part-of-speech tags. See:
+                # - https://spacy.io/usage/linguistic-features#pos-tagging
+                # - Label scheme section per model at https://spacy.io/models/en
                 'do_not_normalize': {'VBD', 'VBG', 'VBN', 'VBP', 'JJS', 'JJR'},
                 }
 

--- a/medcat/utils/model_creator.py
+++ b/medcat/utils/model_creator.py
@@ -129,6 +129,13 @@ def create_models(config_file):
     cdb = train_unsupervised(cdb, vocab, medcat_config, output_dir, training_data_list)
 
     return cdb, vocab
+def main(config_file):
+    # Setup logging
+    handler = logging.StreamHandler()
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    return create_models(config_file)
 
 
 if __name__ == '__main__':
@@ -140,3 +147,4 @@ if __name__ == '__main__':
 
     # Run pipeline
     create_models(args.config_file)
+    main(args.config_file)

--- a/medcat/utils/model_creator.py
+++ b/medcat/utils/model_creator.py
@@ -8,9 +8,9 @@ from medcat.cat import CAT
 from medcat.config import Config
 from pathlib import Path
 
-# Create Logger
+DEFAULT_UNIGRAM_TABLE_SIZE = 100000000
+
 logger = logging.getLogger(__package__)
-logger.setLevel(logging.INFO)
 
 
 def create_cdb(concept_csv_file, medcat_config):
@@ -58,7 +58,7 @@ def create_vocab(cdb, training_data_list, medcat_config, output_dir, unigram_tab
     return vocab
 
 
-def train_unsupervised(cdb, vocab, medcat_config, output_dir, training_data_list):
+def train_unsupervised(cdb, vocab, config, output_dir, training_data_list):
     """Perform unsupervised training and save updated CDB.
 
     Although not returned explicitly in this function, the CDB will be updated with context embeddings.
@@ -68,7 +68,7 @@ def train_unsupervised(cdb, vocab, medcat_config, output_dir, training_data_list
             MedCAT concept database containing list of entities and synonyms.
         vocab (medcat.vocab.Vocab):
             MedCAT vocabulary created from CDB and training documents.
-        medcat_config (medcat.config.Config):
+        config (medcat.config.Config):
             MedCAT configuration file.
         output_dir (pathlib.Path):
             Output directory to write updated CDB to.
@@ -80,7 +80,7 @@ def train_unsupervised(cdb, vocab, medcat_config, output_dir, training_data_list
             MedCAT concept database containing list of entities and synonyms, as well as context embeddings.
     """
     # Create MedCAT pipeline
-    cat = CAT(cdb=cdb, vocab=vocab, config=medcat_config)
+    cat = CAT(cdb=cdb, vocab=vocab, config=config)
 
     # Perform unsupervised training and add model to concept database
     logger.info('Performing unsupervised training')
@@ -101,34 +101,36 @@ def create_models(config_file):
             Location of model creator configuration file to specify input, output and MedCAT configuration.
 
     Returns:
-        cdb (medcat.cdb.CDB):
-            MedCAT concept database containing list of entities and synonyms, as well as context embeddings.
-        vocab (medcat.vocab.Vocab):
-            MedCAT vocabulary created from CDB and training documents.
+        cat (medcat.cat.CAT):
+            Containing CDB, Vocab and Config
     """
+
     # Load model creator configuration
     with open(config_file, 'r') as stream:
-        config = yaml.safe_load(stream)
+        creator_config = yaml.safe_load(stream)
 
     # Load data for unsupervised training
-    with open(Path(config['unsupervised_training_data_file']), 'r', encoding='utf-8') as training_data:
+    with open(Path(creator_config['unsupervised_training_data_file']), 'r', encoding='utf-8') as training_data:
         training_data_list = [line.strip() for line in training_data]
 
     # Load MedCAT configuration
-    medcat_config = Config()
-    if 'medcat_config_file' in config:
-        medcat_config.parse_config_file(Path(config['medcat_config_file']))
+    config = Config()
+    if 'medcat_config_file' in creator_config:
+        config.parse_config_file(str(Path(creator_config['medcat_config_file'])))
 
     # Create output dir if it does not exist
-    output_dir = Path(config['output_dir'])
+    output_dir = Path(creator_config['output_dir'])
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Create models
-    cdb = create_cdb(Path(config['concept_csv_file']), medcat_config)
-    vocab = create_vocab(cdb, training_data_list, medcat_config, output_dir, config['unigram_table_size'])
-    cdb = train_unsupervised(cdb, vocab, medcat_config, output_dir, training_data_list)
+    # Create and save models
+    cdb = create_cdb(Path(creator_config['concept_csv_file']), config)
+    vocab = create_vocab(cdb, training_data_list, config, output_dir,
+                         creator_config.get('unigram_table_size', DEFAULT_UNIGRAM_TABLE_SIZE))
+    cdb = train_unsupervised(cdb, vocab, config, output_dir, training_data_list)
+    cat = CAT(cdb=cdb, vocab=vocab, config=config)
+    return cat
 
-    return cdb, vocab
+
 def main(config_file):
     # Setup logging
     handler = logging.StreamHandler()
@@ -142,9 +144,7 @@ if __name__ == '__main__':
     # Parse arguments
     parser = argparse.ArgumentParser()
     parser.add_argument('config_file', help='YAML formatted file containing the parameters for model creator. An '
-                                            'example can be found in `tests/model_creator/config_example.yml`')
+                                            'example can be found in `tests/model_creator/config_example.yml`',
+                        type=Path)
     args = parser.parse_args()
-
-    # Run pipeline
-    create_models(args.config_file)
     main(args.config_file)

--- a/tests/model_creator/medcat.txt
+++ b/tests/model_creator/medcat.txt
@@ -3,3 +3,6 @@ cat.preprocessing.do_not_normalize = {}
 cat.general.diacritics = True
 cat.general.spell_check_deep = False
 cat.ner.check_upper_case_names = True
+cat.version.description = 'Small set of sample data for testing purposes'
+cat.version.ontology = 'UMLS'
+cat.version.location = 'https://github.com/CogStack/MedCAT'

--- a/tests/test_entity_linking.py
+++ b/tests/test_entity_linking.py
@@ -1,6 +1,4 @@
 import unittest
-from medcat.cat import CAT
-from medcat.config import Config
 from medcat.utils.model_creator import create_models
 from pathlib import Path
 
@@ -14,11 +12,8 @@ class EntityLinkingTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cdb, vocab = create_models(Path('tests/model_creator/config_example.yml'))
-        medcat_config = Config()
-        medcat_config.parse_config_file(Path('tests/model_creator/medcat.txt'))
-        cls.cat = CAT(cdb=cdb, vocab=vocab, config=medcat_config)
-        cls.cdb = cdb
+        model_creator_config_path = Path('tests/model_creator/config_example.yml')
+        cls.cat = create_models(model_creator_config_path)
 
     def assert_linked_entities(self, doc, expected_entities, unexpected_entities=None):
         """General assertion function to assess linked entities.
@@ -98,7 +93,7 @@ class TestDiacritics(EntityLinkingTest):
     """
 
     def test_diacritics_in_cdb(self):
-        self.assertIn('ménière', self.cdb.cui2snames['C0025281'])
+        self.assertIn('ménière', self.cat.cdb.cui2snames['C0025281'])
 
     def test_diacritics_in_text(self):
         expected_entities = ['C0025281']


### PR DESCRIPTION
- Adding logging reporting functionality to model creator as discussed in #242 
- Improve naming of config in model creator to align with other parts of MedCAT. The previous naming was confusing.
- Simplify model creator test by using letting model creator return a CAT object. 
- Add some documentation on detailed part-of-speech tag. It took me a while to figure out the definitions.
- Use the new version functionality to add some metadata on the test model.