### PR TITLE
Fixed issue due to data type validation when creating a model pack.

### DIFF
--- a/medcat/config.py
+++ b/medcat/config.py
@@ -231,9 +231,9 @@ class MixingConfig(FakeDict):
 class VersionInfo(MixingConfig, BaseModel):
     history: list = []
     """Populated automatically"""
-    meta_cats: dict = dict()
+    meta_cats: Any = {}
     """Populated automatically"""
-    cdb_info: dict = dict()
+    cdb_info: dict = {}
     """Populated automatically, output from cdb.print_stats"""
     performance: dict = {'ner': {}, 'meta': {}}
     """NER general performance, meta should be: {'meta': {'model_name': {'f1': <>, 'p': <>, ...}, ...}}"""


### PR DESCRIPTION
The recent config changes introduced validation of data types in the config(s).

However, the data type for `version.meta_cats` was incorrect. This caused failure due to validation when doing `cat._versioning` during creating a model pack.

The value was set to an empty `dict` in the previous config version so it was set to the same value and type in the new version as well.

However, when a value is set to this field, a list of strings is used.

This PR will fix the issue by allowing any type of objects to be set for `version.meta_cats`