### PR TITLE
CU-2uhvm87 Pin dill version to less than 0.3.5 to satisfy datasets requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         'sklearn~=0.0',
         'elasticsearch>=8.3,<9',  # Check if this is compatible with opensearch otherwise: 'elasticsearch>=7.10,<8.0.0',
         'eland>=8.3.0,<9',
-        'dill~=0.3.4',
+        'dill~=0.3.4,<0.3.5', # less than 0.3.5 due to datasets requirement
         'datasets~=2.2.2',
         'jsonpickle~=2.0.0',
         'psutil<6.0.0,>=5.8.0',


### PR DESCRIPTION
The docs builds have been failing due to the incompatible version of `dill` that gets installed (incompatible with `datasets`).

I've gone ahead and pinned `dill` to a version less than 0.3.5 (the requirement from `datasets`) so that 0.3.4 gets installed.

This _should_ fix the issue for the docs.

What I tried to make sure this fixes the issue:
- Run the below on python 3.9.14
  - Though readthedocs runs 3.9.13, it should be close enough
- Install `dill==0.3.5.1` (as is installed on readthedocs)
  - Run `python ./setup.py install --force` (as is done on readthedocs)
  - Experience an error due to the mismatch (similarly to readthedocs)
- Install `dill==0.3.4`
  - Run `python ./setup.py install --force`
  - Experience **no** errors
