### PR TITLE
Fix issue with logging when setting an attribute fails within MixingConfig

### DIFF
--- a/medcat/config.py
+++ b/medcat/config.py
@@ -123,8 +123,8 @@ class MixingConfig(FakeDict):
             else:
                 try:
                     setattr(self, key, value)
-                except AttributeError as e:
-                    self.log.warning('Issue with setting attribtue', key, ':', e)
+                except AttributeError as err:
+                    self.log.warning('Issue with setting attribtue "%s":', key, exc_info=err)
         self.rebuild_re()
 
     def parse_config_file(self, path: str, extractor: ValueExtractor = _DEFAULT_EXTRACTOR) -> None:


### PR DESCRIPTION
If there was ever an issue with the `setattr` method (the `__setattr__` method fails, i.e due to the _pydantic_ model of an extending class), the logging of this issue would fail due to improper arguments to the logging method.

The previous approach should not crash the entire process (since the people developing the _logging_  library will have caught my mistake). However, it would end up with more information than perhaps is needed. And it is certainly a mistake on my end as well.

PS:
Found this due to a new linter that flagged this and a lot of false-positives elsewhere.