### PR TITLE
CU-2uhvm87 Pin multiprocess, aiohttp and smart-open versions in order…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
         # 0.70.12 uses older version of dill (i.e less than 0.3.5) which is required for datasets
         'multiprocess==0.70.12',  # seems to work better than standard mp
         'aiohttp==3.8.3', # 3.8.3 is needed for compatibility with fsspec
-        'smart-open==5.2.1', # 5.2.1 is needed for compatibility with
+        'smart-open==5.2.1', # 5.2.1 is needed for compatibility with pathy
         'py2neo==2021.2.3',
         'aiofiles~=0.8.0',
         'ipywidgets~=7.6.5',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,10 @@ setuptools.setup(
         'datasets~=2.2.2',
         'jsonpickle~=2.0.0',
         'psutil<6.0.0,>=5.8.0',
-        'multiprocess',  # seems to work better than standard mp
+        # 0.70.12 uses older version of dill (i.e less than 0.3.5) which is required for datasets
+        'multiprocess==0.70.12',  # seems to work better than standard mp
+        'aiohttp==3.8.3', # 3.8.3 is needed for compatibility with fsspec
+        'smart-open==5.2.1', # 5.2.1 is needed for compatibility with
         'py2neo==2021.2.3',
         'aiofiles~=0.8.0',
         'ipywidgets~=7.6.5',


### PR DESCRIPTION
… to fix documentation build

Pinned a few more dependency versions such that (hopefully) the docs building works this time around.

The reason my previous version failed was because I was running it locally on python 3.9.6. However, 3.9.13 is used on readthedocs.

I've now gone and run the setup through a python3.9.14 installation. And the set of dependencies within here seem to have fixed that.

So this should finally be able to build the docs.