### PR TITLE
Make stats reporting not have np.nan values on empty train count 

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -197,7 +197,7 @@ class CAT(object):
                 version.history.append(version['id'])
             version.id = m
             version.last_modified = date.today().strftime("%d %B %Y")
-            version.cdb_info = self.cdb._make_stats()
+            version.cdb_info = self.cdb.make_stats()
             version.meta_cats = [meta_cat.get_model_card(as_dict=True) for meta_cat in self._meta_cats]
             version.medcat_version = __version__
             logger.warning("Please consider updating [description, performance, location, ontology] in cat.config.version")
@@ -256,7 +256,8 @@ class CAT(object):
 
         # Add a model card also, why not
         model_card_path = os.path.join(save_dir_path, "model_card.json")
-        json.dump(self.get_model_card(as_dict=True), open(model_card_path, 'w'), indent=2)
+        with open(model_card_path, 'w') as f:
+            json.dump(self.get_model_card(as_dict=True), f, indent=2)
 
         # Zip everything
         shutil.make_archive(os.path.join(_save_dir_path, model_pack_name), 'zip', root_dir=save_dir_path)

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -550,14 +550,14 @@ class CDB(object):
         self.cui2type_ids = new_cui2type_ids
         self.cui2preferred_name = new_cui2preferred_name
 
-    def _make_stats(self):
+    def make_stats(self):
         stats = {}
         stats["Number of concepts"] = len(self.cui2names)
         stats["Number of names"] = len(self.name2cuis)
         stats["Number of concepts that received training"] = len([cui for cui in self.cui2count_train if self.cui2count_train[cui] > 0])
         stats["Number of seen training examples in total"] = sum(self.cui2count_train.values())
-        stats["Average training examples per concept"] = np.average(
-                [self.cui2count_train[cui] for cui in self.cui2count_train if self.cui2count_train[cui] > 0])
+        positive_count_trains = [self.cui2count_train[cui] for cui in self.cui2count_train if self.cui2count_train[cui] > 0]
+        stats["Average training examples per concept"] = np.average(positive_count_trains) if positive_count_trains else 0.0
 
         return stats
 

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -564,7 +564,7 @@ class CDB(object):
     def print_stats(self) -> None:
         r'''Print basic statistics for the CDB.
         '''
-        logger.info(json.dumps(self._make_stats(), indent=2))
+        logger.info(json.dumps(self.make_stats(), indent=2))
 
     def reset_concept_similarity(self) -> None:
         r''' Reset concept similarity matrix.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         'transformers~=4.19.2',
         'torch>=1.0',
         'tqdm>=4.27',
-        'sklearn~=0.0',
+        'scikit-learn<1.2.0',
         'elasticsearch>=8.3,<9',  # Check if this is compatible with opensearch otherwise: 'elasticsearch>=7.10,<8.0.0',
         'eland>=8.3.0,<9',
         'dill~=0.3.4,<0.3.5', # less than 0.3.5 due to datasets requirement

--- a/tests/test_cdb.py
+++ b/tests/test_cdb.py
@@ -3,6 +3,7 @@ import shutil
 import unittest
 import tempfile
 import asyncio
+import numpy as np
 from medcat.config import Config
 from medcat.cdb_maker import CDBMaker
 
@@ -57,6 +58,12 @@ class CDBTests(unittest.TestCase):
             asyncio.run(self.undertest.save_async(f.name))
             self.undertest.load(f.name)
 
+    def test_empty_count_train(self):
+        copied = dict(self.undertest.cui2count_train)
+        self.undertest.cui2count_train = {}
+        stats = self.undertest.make_stats()
+        self.assertFalse(np.isnan(stats["Average training examples per concept"]))
+        self.undertest.cui2count_train = copied
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR handles an edge case where if the train count is empty, then the `np.average()` will return `nan` which will be leaked into the stats dict. After the dict is serialised in JSON, `nan` becomes `NaN` which invalids the output. Either 0.0 or None (null) can work fmpov.
Before: {..."Average training examples per concept": NaN}
After: {..."Average training examples per concept": 0.0}