### PR TITLE
include joblib dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setuptools.setup(
         # the following are not direct dependencies of MedCAT but needed for docs/building
         'aiohttp==3.8.3', # 3.8.3 is needed for compatibility with fsspec
         'smart-open==5.2.1', # 5.2.1 is needed for compatibility with pathy
+        'joblib~=1.2', 
         ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
trainer and medcat service builds failing due to missing dep. Not sure what was pulling this in transitively before...