### PR TITLE
Support for python3.11 (and 3.10)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.11', '3.10', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.11', '3.10', '3.8', '3.9' ]
       max-parallel: 4
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.11, 3.10, 3.7, 3.8, 3.9 ]
+        python-version: [ '3.11', '3.10', '3.7', '3.8', '3.9' ]
       max-parallel: 4
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.11, 3.10, 3.7, 3.8, 3.9 ]
       max-parallel: 4
 
     steps:

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -359,7 +359,7 @@ class CAT(object):
             return None
         else:
             text = self._get_trimmed_text(str(text))
-            return self.pipe(text)
+            return self.pipe(text)  # type: ignore
 
     def __repr__(self):
         """Prints the model_card for this CAT instance.
@@ -454,7 +454,7 @@ class CAT(object):
                     else:
                         local_filters.cuis = {'empty'}
 
-                spacy_doc: Doc = self(doc['text'])
+                spacy_doc: Doc = self(doc['text'])  # type: ignore
 
                 if use_overlaps:
                     p_anns = spacy_doc._.ents
@@ -767,7 +767,7 @@ class CAT(object):
 
         if spacy_entity is not None and spacy_doc is not None:
             # Train Linking
-            self.linker.context_model.train(cui=cui, entity=spacy_entity, doc=spacy_doc, negative=negative, names=names)
+            self.linker.context_model.train(cui=cui, entity=spacy_entity, doc=spacy_doc, negative=negative, names=names)  # type: ignore
 
             if not negative and devalue_others:
                 # Find all cuis
@@ -779,7 +779,7 @@ class CAT(object):
                     cuis.remove(cui)
                 # Add negative training for all other CUIs that link to these names
                 for _cui in cuis:
-                    self.linker.context_model.train(cui=_cui, entity=spacy_entity, doc=spacy_doc, negative=True)
+                    self.linker.context_model.train(cui=_cui, entity=spacy_entity, doc=spacy_doc, negative=True)  # type: ignore
 
     def train_supervised(self,
                          data_path: str,
@@ -951,7 +951,7 @@ class CAT(object):
 
                 for idx_doc in trange(current_document, len(project['documents']), initial=current_document, total=len(project['documents']), desc='Document', leave=False):
                     doc = project['documents'][idx_doc]
-                    spacy_doc: Doc = self(doc['text'])
+                    spacy_doc: Doc = self(doc['text'])  # type: ignore
 
                     # Compatibility with old output where annotations are a list
                     doc_annotations = self._get_doc_annotations(doc)
@@ -972,8 +972,8 @@ class CAT(object):
                     if train_from_false_positives:
                         fps: List[Span] = get_false_positives(doc, spacy_doc)
 
-                        for fp in fps:
-                            fp_: Span = fp
+                        for fp in fps:  # type: ignore
+                            fp_: Span = fp  # type: ignore
                             self.add_and_train_concept(cui=fp_._.cui,
                                                        name=fp_.text,
                                                        spacy_doc=spacy_doc,
@@ -1015,7 +1015,7 @@ class CAT(object):
                      only_cui: bool = False,
                      addl_info: List[str] = ['cui2icd10', 'cui2ontologies', 'cui2snomed']) -> Dict:
         doc = self(text)
-        out = self._doc_to_out(doc, only_cui, addl_info)
+        out = self._doc_to_out(doc, only_cui, addl_info)  # type: ignore
         return out
 
     def get_entities_multi_texts(self,
@@ -1041,7 +1041,7 @@ class CAT(object):
         if n_process is None:
             texts_ = self._generate_trimmed_texts(texts)
             for text in texts_:
-                out.append(self._doc_to_out(self(text), only_cui, addl_info))
+                out.append(self._doc_to_out(self(text), only_cui, addl_info))  # type: ignore
         else:
             self.pipe.set_error_handler(self._pipe_error_handler)
             try:
@@ -1058,9 +1058,9 @@ class CAT(object):
                     logger.warning("Found at least one failed batch and set output for enclosed texts to empty")
                     for i, text in enumerate(texts_):
                         if i == len(out):
-                            out.append(self._doc_to_out(None, only_cui, addl_info))
+                            out.append(self._doc_to_out(None, only_cui, addl_info))  # type: ignore
                         elif out[i].get('text', '') != text:
-                            out.insert(i, self._doc_to_out(None, only_cui, addl_info))
+                            out.insert(i, self._doc_to_out(None, only_cui, addl_info))  # type: ignore
 
                 cnf_annotation_output = self.config.annotation_output
                 if not(cnf_annotation_output.include_text_in_output):
@@ -1468,7 +1468,7 @@ class CAT(object):
                         entity._.meta_anns = _ent['meta_anns']
                     _ents.append(entity)
             else:
-                _ents = doc.ents
+                _ents = doc.ents  # type: ignore
 
             if cnf_annotation_output.lowercase_context:
                 doc_tokens = [tkn.text_with_ws.lower() for tkn in list(doc)]
@@ -1551,10 +1551,10 @@ class CAT(object):
 
     @staticmethod
     def _get_doc_annotations(doc: Doc):
-        if type(doc['annotations']) == list:
-            return doc['annotations']
-        if type(doc['annotations']) == dict:
-            return doc['annotations'].values()
+        if type(doc['annotations']) == list:  # type: ignore
+            return doc['annotations']  # type: ignore
+        if type(doc['annotations']) == dict:  # type: ignore
+            return doc['annotations'].values()  # type: ignore
         return None
 
     def destroy_pipe(self):

--- a/medcat/linking/context_based_linker.py
+++ b/medcat/linking/context_based_linker.py
@@ -55,7 +55,8 @@ class Linker(PipeRunner):
 
     # Override
     def __call__(self, doc: Doc) -> Doc:
-        doc.ents = [] # Reset main entities, will be recreated later
+        # Reset main entities, will be recreated later  
+        doc.ents = []  # type: ignore
         cnf_l = self.config.linking
         linked_entities = []
 

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -432,17 +432,17 @@ class MetaCAT(PipeRunner):
         batch_size_chars = config.general['pipe_batch_size_in_chars']
 
         if config.general['device'] == 'cpu' or config.general['disable_component_lock']:
-            yield from self._set_meta_anns(stream, batch_size_chars, config, id2category_value)
+            yield from self._set_meta_anns(stream, batch_size_chars, config, id2category_value)  # type: ignore
         else:
             with MetaCAT._component_lock:
-                yield from self._set_meta_anns(stream, batch_size_chars, config, id2category_value)
+                yield from self._set_meta_anns(stream, batch_size_chars, config, id2category_value)  # type: ignore
 
     def _set_meta_anns(self,
                        stream: Iterable[Union[Doc, FakeDoc]],
                        batch_size_chars: int,
                        config: ConfigMetaCAT,
                        id2category_value: Dict) -> Iterator[Optional[Doc]]:
-        for docs in self.batch_generator(stream, batch_size_chars):
+        for docs in self.batch_generator(stream, batch_size_chars):  # type: ignore
             try:
                 if not config.general['save_and_reuse_tokens'] or docs[0]._.share_tokens is None:
                     if config.general['lowercase']:

--- a/medcat/ner/transformers_ner.py
+++ b/medcat/ner/transformers_ner.py
@@ -331,19 +331,19 @@ class TransformersNER(object):
             return stream
 
         batch_size_chars = self.config.general['pipe_batch_size_in_chars']
-        yield from self._process(stream, batch_size_chars)
+        yield from self._process(stream, batch_size_chars)  # type: ignore
 
     def _process(self,
                  stream: Iterable[Union[Doc, None]],
                  batch_size_chars: int) -> Iterator[Optional[Doc]]:
-        for docs in self.batch_generator(stream, batch_size_chars):
+        for docs in self.batch_generator(stream, batch_size_chars):  # type: ignore
             #all_text = [doc.text for doc in docs]
             #all_text_processed = self.tokenizer.encode_eval(all_text)
             # For now we will process the documents one by one, should be improved in the future to use batching
             for doc in docs:
                 try:
                     res = self.ner_pipe(doc.text, aggregation_strategy=self.config.general['ner_aggregation_strategy'])
-                    doc.ents = []
+                    doc.ents = []  # type: ignore
                     for r in res:
                         inds = []
                         for ind, word in enumerate(doc):

--- a/medcat/pipe.py
+++ b/medcat/pipe.py
@@ -139,7 +139,7 @@ class Pipe(object):
     def add_addl_ner(self, addl_ner: TransformersNER, name: Optional[str] = None) -> None:
         component_name = spacy.util.get_object_name(addl_ner)
         name = name if name is not None else component_name
-        Language.component(name=component_name, func=addl_ner)
+        Language.component(name=component_name, func=addl_ner)  # type: ignore
         self._nlp.add_pipe(component_name, name=name, last=True)
 
         Doc.set_extension('ents', default=[], force=True)
@@ -176,7 +176,7 @@ class Pipe(object):
             self._nlp.get_pipe(instance_name)
         except KeyError:
             component_name = spacy.util.get_object_name(self._ensure_serializable)
-            Language.component(name=component_name, func=self._ensure_serializable)
+            Language.component(name=component_name, func=self._ensure_serializable)  # type: ignore
             self._nlp.add_pipe(component_name, name=instance_name, last=True)
 
         n_process = n_process if n_process is not None else max(cpu_count() - 1, 1)
@@ -238,7 +238,7 @@ class Pipe(object):
 
     def __call__(self, text: Union[str, Iterable[str]]) -> Union[Doc, List[Doc]]:
         if isinstance(text, str):
-            return self._nlp(text) if len(text) > 0 else None
+            return self._nlp(text) if len(text) > 0 else None  # type: ignore
         elif isinstance(text, Iterable):
             docs = []
             for t in text if isinstance(text, types.GeneratorType) else tqdm(text, total=len(list(text))):
@@ -249,7 +249,7 @@ class Pipe(object):
                     logger.warning(e, exc_info=True, stack_info=True)
                     doc = None
                 docs.append(doc)
-            return docs
+            return docs  # type: ignore
         else:
             logger.error("The input text should be either a string or a sequence of strings but got: %s", type(text))
             return None

--- a/medcat/pipeline/pipe_runner.py
+++ b/medcat/pipeline/pipe_runner.py
@@ -24,7 +24,7 @@ class PipeRunner(Pipe):
         raise NotImplementedError("Method __call__ has not been implemented.")
 
     # Override
-    def pipe(self, stream: Iterable[Doc], batch_size: int, **kwargs) -> Union[Generator[Doc, None, None], Iterator[Doc]]:
+    def pipe(self, stream: Iterable[Doc], batch_size: int, **kwargs) -> Union[Generator[Doc, None, None], Iterator[Doc]]:  # type: ignore
         error_handler = self.get_error_handler()
         if kwargs.get("parallel", False):
             PipeRunner._execute, PipeRunner._delayed = self._lazy_init_pool()
@@ -35,14 +35,14 @@ class PipeRunner(Pipe):
                     for output_doc in PipeRunner._execute(tasks):
                         yield PipeRunner.deserialize_entities(output_doc)
                 except Exception as e:
-                    error_handler(self.name, self, docs, e)
+                    error_handler(self.name, self, docs, e)  # type: ignore
                     yield from [None] * len(docs)
         else:
             for doc in stream:
                 try:
                     yield self(doc)
                 except Exception as e:
-                    error_handler(self.name, self, [doc], e)
+                    error_handler(self.name, self, [doc], e)  # type: ignore
                     yield None
 
     @staticmethod
@@ -89,7 +89,7 @@ class PipeRunner(Pipe):
 
     @staticmethod
     def _run_pipe_on_one(call: Callable, doc: Doc, underscore_state: Tuple) -> Doc:
-        Underscore.load_state(underscore_state)
+        Underscore.load_state(underscore_state)  # type: ignore
         doc = PipeRunner.deserialize_entities(doc)
         doc = call(doc)
         doc = PipeRunner.serialize_entities(doc)

--- a/medcat/utils/postprocessing.py
+++ b/medcat/utils/postprocessing.py
@@ -31,7 +31,7 @@ def make_pretty_labels(cdb: CDB, doc: Doc, style: Optional[LabelStyle] = None) -
             setattr(n_ent._, attr, getattr(ent._, attr))
         n_ents.append(n_ent)
 
-    doc.ents = n_ents
+    doc.ents = n_ents  # type: ignore
 
 
 def create_main_ann(cdb: CDB, doc: Doc, tuis: Optional[List] = None) -> None:
@@ -59,4 +59,4 @@ def create_main_ann(cdb: CDB, doc: Doc, tuis: Optional[List] = None) -> None:
                     tkns_in.add(tkn)
                 main_anns.append(ent)
 
-    doc.ents = list(doc.ents) + main_anns
+    doc.ents = list(doc.ents) + main_anns  # type: ignore

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 .
 https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.4.0/en_core_web_md-3.4.0-py3-none-any.whl
 flake8==4.0.1
-mypy==0.931
+mypy==0.981
 mypy-extensions==0.4.3
 types-aiofiles==0.8.3
 types-PyYAML==6.0.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 .
-https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.1.0/en_core_web_md-3.1.0-py3-none-any.whl
+https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.4.0/en_core_web_md-3.4.0-py3-none-any.whl
 flake8==4.0.1
 mypy==0.931
 mypy-extensions==0.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 .
-https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.1.0/en_core_web_md-3.1.0-py3-none-any.whl
+https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.4.0/en_core_web_md-3.4.0-py3-none-any.whl

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ setuptools.setup(
         # however, there's not been a release yet
         # so this will install the tested github state of the package
         'gensim@git+ssh://git@github.com/RaRe-Technologies/gensim.git@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2',
-        'spacy>=3.1.0,<3.1.4', # later versions seem to have en_core_web_md differences
+        # seems like we need the en_core_web_md from version 3.1.3
+        # but overall, 3.4.3 works the best, mostly becasue before that pydantic 1.10 is not supported
+        'spacy>=3.1.0',
         'scipy~=1.9.2', # first to support 3.11
         'transformers>=4.19.2',
         'torch>=1.13.0', # first to support 3.11

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         # and they've implemented 3.11 support in thir dervelopmnet branch
         # however, there's not been a release yet
         # so this will install the tested github state of the package
-        'git+https://github.com/RaRe-Technologies/gensim@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2',
+        'git+https://github.com/RaRe-Technologies/gensim.git@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2#egg=gensim',
         'spacy>=3.1.0,<3.1.4', # later versions seem to have en_core_web_md differences
         'scipy~=1.9.2', # first to support 3.11
         'transformers>=4.19.2',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         # and they've implemented 3.11 support in thir dervelopmnet branch
         # however, there's not been a release yet
         # so this will install the tested github state of the package
-        'gensim@git+https://github.com/RaRe-Technologies/gensim.git@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2#egg=gensim',
+        'gensim@git+ssh://git@github.com/RaRe-Technologies/gensim.git@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2',
         'spacy>=3.1.0,<3.1.4', # later versions seem to have en_core_web_md differences
         'scipy~=1.9.2', # first to support 3.11
         'transformers>=4.19.2',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         # and they've implemented 3.11 support in thir dervelopmnet branch
         # however, there's not been a release yet
         # so this will install the tested github state of the package
-        'git+https://github.com/RaRe-Technologies/gensim.git@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2#egg=gensim',
+        'gensim@git+https://github.com/RaRe-Technologies/gensim.git@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2#egg=gensim',
         'spacy>=3.1.0,<3.1.4', # later versions seem to have en_core_web_md differences
         'scipy~=1.9.2', # first to support 3.11
         'transformers>=4.19.2',

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         'psutil<6.0.0,>=5.8.0',
         # 0.70.12 uses older version of dill (i.e less than 0.3.5) which is required for datasets
         'multiprocess~=0.70.12',  # 0.70.14 seemed to work just fine
-        'py2neo~=2021.2.3'
+        'py2neo~=2021.2.3',
         'aiofiles>=0.8.0', # allow later versions, tested with 22.1.0
         'ipywidgets>=7.6.5', # allow later versions, tested with 0.8.0
         'xxhash>=3.0.0', # allow later versions, tested with 3.1.0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         # and they've implemented 3.11 support in thir dervelopmnet branch
         # however, there's not been a release yet
         # so this will install the tested github state of the package
-        'gensim@git+ssh://git@github.com/RaRe-Technologies/gensim.git@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2',
+        'gensim@git+https://github.com/RaRe-Technologies/gensim.git@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2',
         # seems like we need the en_core_web_md from version 3.1.3
         # but overall, 3.4.3 works the best, mostly becasue before that pydantic 1.10 is not supported
         'spacy>=3.1.0',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         # and they've implemented 3.11 support in thir dervelopmnet branch
         # however, there's not been a release yet
         # so this will install the tested github state of the package
-        'gensim @ git+https://github.com/RaRe-Technologies/gensim@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2',
+        'git+https://github.com/RaRe-Technologies/gensim@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2',
         'spacy>=3.1.0,<3.1.4', # later versions seem to have en_core_web_md differences
         'scipy~=1.9.2', # first to support 3.11
         'transformers>=4.19.2',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     url="https://github.com/CogStack/MedCAT",
     packages=['medcat', 'medcat.utils', 'medcat.preprocessing', 'medcat.cogstack', 'medcat.ner', 'medcat.linking', 'medcat.datasets',
               'medcat.tokenizers', 'medcat.utils.meta_cat', 'medcat.pipeline', 'medcat.neo', 'medcat.utils.ner',
-              'medcat.utils.saving', 'medcat.utils.regression'],
+              'medcat.utils.regression'],
     install_requires=[
         'numpy>=1.22.0', # first to support 3.11
         'pandas>=1.4.2', # first to support 3.11

--- a/setup.py
+++ b/setup.py
@@ -15,36 +15,43 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/CogStack/MedCAT",
     packages=['medcat', 'medcat.utils', 'medcat.preprocessing', 'medcat.cogstack', 'medcat.ner', 'medcat.linking', 'medcat.datasets',
-              'medcat.tokenizers', 'medcat.utils.meta_cat', 'medcat.pipeline', 'medcat.neo', 'medcat.utils.ner', 'medcat.utils.regression'],
+              'medcat.tokenizers', 'medcat.utils.meta_cat', 'medcat.pipeline', 'medcat.neo', 'medcat.utils.ner',
+              'medcat.utils.saving', 'medcat.utils.regression'],
     install_requires=[
-        'numpy>=1.21.4',
-        'pandas<=1.4.2,>=1.1.5',
-        'gensim~=4.1.2',
-        'spacy<3.1.4,>=3.1.0',
-        'scipy<=1.8.1,>=1.5.4',
-        'transformers~=4.19.2',
-        'torch>=1.0',
+        'numpy>=1.22.0', # first to support 3.11
+        'pandas>=1.4.2', # first to support 3.11
+        # note from 13.12.2022:
+        # gensim has python 3.11 support for pre 4.0.0 versions
+        # and they've implemented 3.11 support in thir dervelopmnet branch
+        # however, there's not been a release yet
+        # so this will install the tested github state of the package
+        'gensim @ git+https://github.com/RaRe-Technologies/gensim@ca8e4e8378bc489b0dda087dd9c0ed8f933ca3e2',
+        'spacy>=3.1.0,<3.1.4', # later versions seem to have en_core_web_md differences
+        'scipy~=1.9.2', # first to support 3.11
+        'transformers>=4.19.2',
+        'torch>=1.13.0', # first to support 3.11
         'tqdm>=4.27',
-        'scikit-learn<1.2.0',
+        'scikit-learn>=1.1.3', # first to supporrt 3.11
         'elasticsearch>=8.3,<9',  # Check if this is compatible with opensearch otherwise: 'elasticsearch>=7.10,<8.0.0',
         'eland>=8.3.0,<9',
-        'dill~=0.3.4,<0.3.5', # less than 0.3.5 due to datasets requirement
-        'datasets~=2.2.2',
-        'jsonpickle~=2.0.0',
+        'dill>=0.3.4', # allow later versions with later versions of datasets (tested with 0.3.6)
+        'datasets>=2.2.2', # allow later versions, tested with 2.7.1
+        'jsonpickle>=2.0.0', # allow later versions, tested with 3.0.0
         'psutil<6.0.0,>=5.8.0',
         # 0.70.12 uses older version of dill (i.e less than 0.3.5) which is required for datasets
-        'multiprocess==0.70.12',  # seems to work better than standard mp
-        'py2neo==2021.2.3',
-        'aiofiles~=0.8.0',
-        'ipywidgets~=7.6.5',
-        'xxhash==3.0.0',
-        'blis<=0.7.5',
-        'click<=8.0.4',  # Spacy breaks without this
-        'pydantic!=1.8,!=1.8.1,<1.9.0,>=1.7.4', # identical constraints to thinc and spacy
+        'multiprocess~=0.70.12',  # 0.70.14 seemed to work just fine
+        'py2neo~=2021.2.3'
+        'aiofiles>=0.8.0', # allow later versions, tested with 22.1.0
+        'ipywidgets>=7.6.5', # allow later versions, tested with 0.8.0
+        'xxhash>=3.0.0', # allow later versions, tested with 3.1.0
+        'blis>=0.7.5', # allow later versions, tested with 0.7.9
+        'click>=8.0.4', # allow later versions, tested with 8.1.3
+        'pydantic>=1.10.0', # for spacy compatibility
         # the following are not direct dependencies of MedCAT but needed for docs/building
-        'aiohttp==3.8.3', # 3.8.3 is needed for compatibility with fsspec
-        'smart-open==5.2.1', # 5.2.1 is needed for compatibility with pathy
-        'joblib~=1.2', 
+        # hopefully will no longer need the transitive dependencies
+        # 'aiohttp==3.8.3', # 3.8.3 is needed for compatibility with fsspec
+        # 'smart-open==5.2.1', # 5.2.1 is needed for compatibility with pathy
+        # 'joblib~=1.2',
         ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -71,7 +71,7 @@ class A_NERTests(unittest.TestCase):
     def test_aa_cdb_names_output(self):
         target_result = {'S-229004': {'movar~viruse', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}
         from platform import python_version
-        major, minor, patch = python_version()
+        major, minor, patch = python_version().split('.')
         if major == 3 and minor == 11:
             print("Fixing 'movar~viruse' -> 'movar-virus' for newere en_core_web_md")
             target_result = {'S-229004': {'movar~virus', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -72,7 +72,7 @@ class A_NERTests(unittest.TestCase):
         target_result = {'S-229004': {'movar~viruse', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}
         from platform import python_version
         major, minor, patch = python_version().split('.')
-        if major == 3 and minor == 11:
+        if major == '3' and minor == '11':
             print("Fixing 'movar~viruse' -> 'movar-virus' for newere en_core_web_md")
             target_result = {'S-229004': {'movar~virus', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}
         self.assertEqual(self.cdb.cui2names, target_result)

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -70,6 +70,11 @@ class A_NERTests(unittest.TestCase):
 
     def test_aa_cdb_names_output(self):
         target_result = {'S-229004': {'movar~viruse', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}
+        from platform import python_version
+        major, minor, patch = python_version()
+        if major == 3 and minor == 11:
+            print("Fixing 'movar~viruse' -> 'movar-virus' for newere en_core_web_md")
+            target_result = {'S-229004': {'movar~virus', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}
         self.assertEqual(self.cdb.cui2names, target_result)
 
     def test_ab_entities_length(self):

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -69,12 +69,8 @@ class A_NERTests(unittest.TestCase):
         cls.pipe.destroy()
 
     def test_aa_cdb_names_output(self):
-        target_result = {'S-229004': {'movar~viruse', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}
-        from platform import python_version
-        major, minor, patch = python_version().split('.')
-        if major == '3' and minor == '11':
-            print("Fixing 'movar~viruse' -> 'movar-virus' for newere en_core_web_md")
-            target_result = {'S-229004': {'movar~virus', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}
+        print("Fixing 'movar~viruse' -> 'movar-virus' for newere en_core_web_md")
+        target_result = {'S-229004': {'movar~virus', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}
         self.assertEqual(self.cdb.cui2names, target_result)
 
     def test_ab_entities_length(self):


### PR DESCRIPTION
Python3.11 has been widely publicised to be considerably faster (10-60%, on average 25% [according to the docs](https://docs.python.org/3/whatsnew/3.11.html)).
And since MedCAT is operating on large amounts of data (which can take a long time), we thought it was high time we explore whether or how MedCAT runs on this new and faster python version.

With that said **there are multiple important caveats** to the changes introduced by this PR.
Some of the more noteworthy ones:
- Dropped support for python 3.7
- Dependence on `en_core_web_md` vs 3.4.0 (previously 3.1.0)
- Many dependency versions were updated with little to no overlap
- There are no guarantees of increased performance (as it is heavily dependant on dependencies)

So the notable changes:
- Updated dependency versions so that they support python 3.11
- Update `en_core_web_md` version so that it works with the rest of the dependencies
  - I do not have enough domain knowledge to know whether or not this has any other side effects, it may
- Update mypy to support 3.11
  - This also meant adding some additional ignore comments

I am more than open to any further suggestions and/or feedback.

PS:
We might get away with slightly fewer changes if we just wanted to stick to python 3.10 and not include 3.11.

PPS:
I have not done any meaningful performance comparisons. The best I can offer is numbers from GitHub Actions. And in those, 3.11 comes up last. But there are many potential reasons for this, from potentially using different (i.e different sized) dependency versions (I didn't check) to being allocated fewer resources.