### PR TITLE
CU-39cmvru Faster hashing

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -136,10 +136,20 @@ class CAT(object):
         """Returns the spacy pipeline with MedCAT"""
         return self.pipe.spacy_nlp
 
-    def get_hash(self):
-        """Will not be a deep hash but will try to catch all the changing parts during training."""
+    def get_hash(self, force_recalc: bool = False) -> str:
+        """Will not be a deep hash but will try to catch all the changing parts during training.
+
+        Able to force recalculation of hash. This is relevant for CDB
+        the hash for which is otherwise only recalculated if it has changed.
+
+        Args:
+            force_recalc (bool, optional): Whether to force recalculation. Defaults to False.
+
+        Returns:
+            str: The resulting hash
+        """
         hasher = Hasher()
-        hasher.update(self.cdb.get_hash())
+        hasher.update(self.cdb.get_hash(force_recalc))
 
         hasher.update(self.config.get_hash())
 

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -653,6 +653,9 @@ class CAT(object):
             self.cdb.reset_training()
         checkpoint = self._init_ckpts(is_resumed, checkpoint)
 
+        # cache train state
+        _prev_train = self.config.linking.train
+
         latest_trained_step = checkpoint.count if checkpoint is not None else 0
         epochal_data_iterator = chain.from_iterable(repeat(data_iterator, nepochs))
         for line in islice(epochal_data_iterator, latest_trained_step, None):
@@ -674,7 +677,7 @@ class CAT(object):
             if checkpoint is not None and checkpoint.steps is not None and latest_trained_step % checkpoint.steps == 0:
                 checkpoint.save(cdb=self.cdb, count=latest_trained_step)
 
-        self.config.linking.train = False
+        self.config.linking.train = _prev_train
 
     def add_cui_to_group(self, cui: str, group_name: str) -> None:
         """Adds a CUI to a group, will appear in cdb.addl_info['cui2group']

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -194,13 +194,13 @@ class CAT(object):
         else:
             return json.dumps(card, indent=2, sort_keys=False)
 
-    def _versioning(self):
+    def _versioning(self, force_rehash: bool = False):
         # Check version info and do not allow without it
         if self.config.version.description == 'No description':
             logger.warning("Please consider populating the version information [description, performance, location, ontology] in cat.config.version")
 
         # Fill the stuff automatically that is needed for versioning
-        m = self.get_hash()
+        m = self.get_hash(force_recalc=force_rehash)
         version = self.config.version
         if version.id is None or m != version.id:
             if version.id is not None:
@@ -212,7 +212,7 @@ class CAT(object):
             version.medcat_version = __version__
             logger.warning("Please consider updating [description, performance, location, ontology] in cat.config.version")
 
-    def create_model_pack(self, save_dir_path: str, model_pack_name: str = DEFAULT_MODEL_PACK_NAME) -> str:
+    def create_model_pack(self, save_dir_path: str, model_pack_name: str = DEFAULT_MODEL_PACK_NAME, force_rehash: bool = False) -> str:
         """Will crete a .zip file containing all the models in the current running instance
         of MedCAT. This is not the most efficient way, for sure, but good enough for now.
 
@@ -221,6 +221,8 @@ class CAT(object):
                 An id will be appended to this name
             model_pack_name (str, optional):
                 The model pack name. Defaults to DEFAULT_MODEL_PACK_NAME.
+            force_rehash (bool, optional):
+                Force recalculation of hash. Defaults to `False`.
 
         Returns:
             str:
@@ -229,7 +231,7 @@ class CAT(object):
         # Spacy model always should be just the name, but during loading it can be reset to path
         self.config.general.spacy_model = os.path.basename(self.config.general.spacy_model)
         # Versioning
-        self._versioning()
+        self._versioning(force_rehash)
         model_pack_name += "_{}".format(self.config.version.id)
 
         logger.warning("This will save all models into a zip file, can take some time and require quite a bit of disk space.")

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -380,13 +380,18 @@ class CDB(object):
             self.cui2count_train[cui] += 1
         self.is_dirty = True
 
-    def save(self, path: str) -> None:
+    def save(self, path: str, calc_hash_if_missing: bool = False) -> None:
         """Saves model to file (in fact it saves variables of this class).
 
         Args:
             path (str):
                 Path to a file where the model will be saved
+            calc_hash_if_missing (bool):
+                Calculate the hash if it's missing. Defaults to `False`
         """
+        if calc_hash_if_missing and not self._hash:
+            # get instead of calculate so that the CDB is marked as not dirty if it was dirty
+            self.get_hash()
         with open(path, 'wb') as f:
             # No idea how to this correctly
             to_save = {}

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -702,11 +702,13 @@ or download the compatible model."""
 
     def get_hash(self, force_recalc: bool = False):
         if not force_recalc and self._hash and not self.is_dirty:
+            logger.info("Resuing old hash of CDB since the CDB has not changed: %s", self._hash)
             return self._hash
         self.is_dirty = False
         return self.calculate_hash()
 
     def calculate_hash(self):
+        logger.info("Recalculating hash for CDB, this may take a while")
         hasher = Hasher()
 
         for k,v in self.__dict__.items():
@@ -721,4 +723,5 @@ or download the compatible model."""
                 hasher.update(v, length=True)
 
         self._hash = hasher.hexdigest()
+        logger.info("Found new CDB hash: %s", self._hash)
         return self._hash

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -712,6 +712,11 @@ or download the compatible model."""
         for k,v in self.__dict__.items():
             if k in ['cui2countext_vectors', 'name2cuis']:
                 hasher.update(v, length=False)
+            elif k in ['_hash', 'is_dirty']:
+                # ignore _hash since if it previously didn't exist, the
+                # new hash would be different when the value does exist
+                # and ignore is_dirty so that we get the same hash as previously
+                continue
             elif k != 'config':
                 hasher.update(v, length=True)
 

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -702,7 +702,7 @@ or download the compatible model."""
 
     def get_hash(self, force_recalc: bool = False):
         if not force_recalc and self._hash and not self.is_dirty:
-            logger.info("Resuing old hash of CDB since the CDB has not changed: %s", self._hash)
+            logger.info("Reusing old hash of CDB since the CDB has not changed: %s", self._hash)
             return self._hash
         self.is_dirty = False
         return self.calculate_hash()

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -700,8 +700,8 @@ which may or may not work. If you experience any compatibility issues, please re
 or download the compatible model."""
             )
 
-    def get_hash(self):
-        if self._hash and not self.is_dirty:
+    def get_hash(self, force_recalc: bool = False):
+        if not force_recalc and self._hash and not self.is_dirty:
             return self._hash
         self.is_dirty = False
         return self.calculate_hash()

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -470,6 +470,7 @@ class CDB(object):
 
                 # Increase the vector count
                 self.cui2count_train[cui] = self.cui2count_train.get(cui, 0) + cdb.cui2count_train[cui]
+        self.is_dirty = True
 
     def reset_cui_count(self, n: int = 10) -> None:
         """Reset the CUI count for all concepts that received training, used when starting new unsupervised training
@@ -485,6 +486,7 @@ class CDB(object):
         """
         for cui in self.cui2count_train.keys():
             self.cui2count_train[cui] = n
+        self.is_dirty = True
 
     def reset_training(self) -> None:
         """Will remove all training efforts - in other words all embeddings that are learnt
@@ -494,6 +496,7 @@ class CDB(object):
         self.cui2count_train = {}
         self.cui2context_vectors = {}
         self.reset_concept_similarity()
+        self.is_dirty = True
 
     def filter_by_cui(self, cuis_to_keep: Union[List[str], Set[str]]) -> None:
         """Subset the core CDB fields (dictionaries/maps). Note that this will potenitally keep a bit more CUIs
@@ -564,6 +567,7 @@ class CDB(object):
         self.cui2tags = new_cui2tags
         self.cui2type_ids = new_cui2type_ids
         self.cui2preferred_name = new_cui2preferred_name
+        self.is_dirty = True
 
     def make_stats(self):
         stats = {}
@@ -583,6 +587,7 @@ class CDB(object):
     def reset_concept_similarity(self) -> None:
         """Reset concept similarity matrix."""
         self.addl_info['similarity'] = {}
+        self.is_dirty = True
 
     def most_similar(self,
                      cui: str,

--- a/tests/utils/test_hashing.py
+++ b/tests/utils/test_hashing.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 import unittest.mock
 
@@ -8,6 +9,7 @@ from medcat.vocab import Vocab
 
 
 class CDBHashingTests(unittest.TestCase):
+    temp_dir = tempfile.TemporaryDirectory()
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -18,6 +20,14 @@ class CDBHashingTests(unittest.TestCase):
         h1 = self.cdb.get_hash(force_recalc=True)
         h2 = self.cdb.get_hash(force_recalc=True)
         self.assertEqual(h1, h2)
+
+    def test_CDB_hash_saves_on_disk(self):
+        h = self.cdb.get_hash(force_recalc=True)  # make sure there's a hash
+        temp_file = os.path.join(self.temp_dir.name, 'cdb.dat')
+        self.cdb.save(temp_file)
+
+        cdb = CDB.load(temp_file)
+        self.assertEqual(h, cdb._hash)
 
 
 class BaseCATHashingTests(unittest.TestCase):

--- a/tests/utils/test_hashing.py
+++ b/tests/utils/test_hashing.py
@@ -7,6 +7,19 @@ from medcat.cdb import CDB
 from medcat.vocab import Vocab
 
 
+class CDBHashingTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.cdb = CDB.load(os.path.join(os.path.dirname(
+            os.path.realpath(__file__)), "..", "..", "examples", "cdb.dat"))
+
+    def test_recalc_hash_same(self):
+        h1 = self.cdb.get_hash(force_recalc=True)
+        h2 = self.cdb.get_hash(force_recalc=True)
+        self.assertEqual(h1, h2)
+
+
 class BaseCATHashingTests(unittest.TestCase):
 
     @classmethod
@@ -36,6 +49,18 @@ class CATHashingTestsWithFakeHash(BaseCATHashingTests):
 
     def tearDown(self) -> None:
         self.undertest.cdb._hash = None  # TODO what if under test has a hash?
+
+
+class CATHashingTestsWithoutChangeRecalc(CATHashingTestsWithFakeHash):
+
+    def test_no_changes_can_recalc(self):
+        h = self.undertest.get_hash(force_recalc=True)
+        self.assertIsInstance(h, str)
+
+    def test_no_changes_recalc_same(self):
+        h1 = self.undertest.get_hash(force_recalc=True)
+        h2 = self.undertest.get_hash(force_recalc=True)
+        self.assertEqual(h1, h2)
 
 
 class CATHashingTestsWithoutChange(CATHashingTestsWithFakeHash):

--- a/tests/utils/test_hashing.py
+++ b/tests/utils/test_hashing.py
@@ -1,0 +1,80 @@
+import os
+import unittest
+import unittest.mock
+
+from medcat.cat import CAT
+from medcat.cdb import CDB
+from medcat.vocab import Vocab
+
+
+class BaseCATHashingTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.cdb = CDB.load(os.path.join(os.path.dirname(
+            os.path.realpath(__file__)), "..", "..", "examples", "cdb.dat"))
+        cls.vocab = Vocab.load(os.path.join(os.path.dirname(
+            os.path.realpath(__file__)), "..", "..",  "examples", "vocab.dat"))
+        cls.cdb.config.general.spacy_model = "en_core_web_md"
+        cls.cdb.config.ner.min_name_len = 2
+        cls.cdb.config.ner.upper_case_limit_len = 3
+        cls.cdb.config.general.spell_check = True
+        cls.cdb.config.linking.train_count_threshold = 10
+        cls.cdb.config.linking.similarity_threshold = 0.3
+        cls.cdb.config.linking.train = True
+        cls.cdb.config.linking.disamb_length_limit = 5
+        cls.cdb.config.general.full_unlink = True
+        cls.undertest = CAT(
+            cdb=cls.cdb, config=cls.cdb.config, vocab=cls.vocab)
+
+
+class CATHashingTestsWithFakeHash(BaseCATHashingTests):
+    _fake_hash = 'ffff0000'
+
+    def setUp(self) -> None:
+        self.undertest.cdb._hash = self._fake_hash
+
+    def tearDown(self) -> None:
+        self.undertest.cdb._hash = None  # TODO what if under test has a hash?
+
+
+class CATHashingTestsWithoutChange(CATHashingTestsWithFakeHash):
+
+    def test_no_changes_no_calc(self):
+        self.undertest.cdb.calculate_hash = unittest.mock.Mock()
+        hash = self.undertest.get_hash()
+        self.assertIsInstance(hash, str)
+        self.undertest.cdb.calculate_hash.assert_not_called()
+
+
+class CATHashingTestsWithChange(CATHashingTestsWithFakeHash):
+    # {name: {'tokens': tokens, 'snames': snames, 'raw_name': raw_name}, ...}
+    concept_kwargs = dict(cui='C1232', names={'c1232-name': {'tokens': {},
+                                                             'snames': 'c1232-name', 'raw_name': 'c1232-name', 'is_upper': False}},
+                          ontologies=set(), name_status='P', type_ids=set(), description='TEST')
+
+    def test_when_changes_do_calc(self):
+        with unittest.mock.patch.object(CDB, 'calculate_hash', return_value='abcd1234') as patch_method:
+            self.undertest.cdb.add_concept(**self.concept_kwargs)
+            hash = self.undertest.get_hash()
+        self.assertIsInstance(hash, str)
+        patch_method.assert_called()
+
+
+class CATDirtTestsWithChange(CATHashingTestsWithFakeHash):
+    # {name: {'tokens': tokens, 'snames': snames, 'raw_name': raw_name}, ...}
+    concept_kwargs = dict(cui='C1232', names={'c1232-name': {'tokens': {},
+                                                             'snames': 'c1232-name', 'raw_name': 'c1232-name', 'is_upper': False}},
+                          ontologies=set(), name_status='P', type_ids=set(), description='TEST')
+
+    def test_default_cdb_not_dirty(self):
+        self.assertFalse(self.undertest.cdb.is_dirty)
+
+    def test_after_add_concept_is_dirty(self):
+        self.undertest.cdb.add_concept(**self.concept_kwargs)
+        self.assertTrue(self.undertest.cdb.is_dirty)
+
+    def test_after_recalc_not_dirty(self):
+        self.undertest.cdb.add_concept(**self.concept_kwargs)
+        self.undertest.get_hash()
+        self.assertFalse(self.undertest.cdb.is_dirty)


### PR DESCRIPTION
Hashing of model packs has been quite slow. This is, in large part, due to the large amount of data being hashed within the CDB. However, in practice, the CDB may not always change. Thus, rehashing it may be a waste of resources (i.e time).

What this PR does is cache the hash for a CDB in memory and track whether or not the CDB has changed (i.e is _dirty_). If the CDB is not dirty, its previous hash is used (if present / known); only if the CDB is dirty (or the hash was not previously known), is the hash recalculated.

The hash is saved on disk, if known. The user can also specify to calculate the hash when saving the CDB if one isn't known. The hash may not be known if the CDB is saved outside a model pack and no hash was read from disk. When saved within a model pack, the hash is known since it is used as part of the model's ID/hash and has thus been calculated.

The PR allows for the user to force the recalculation of the CDB hash as well. Both when saving the model pack as well as when simply getting the hash of the CDB. This is in case the CDB internals (i.e the various dicts) are manipulated outside the API that is provided (for whatever reason; this should not be an issue in normal operation).

PS:
The default behaviour now is to use the cached CDB hash (if present). That is to say, the default behaviour has changed.

PPS:
The PR does make calculating the hash significantly faster. I did some preliminary testing on Anthony's 1.4 model as well as the UMLS model and this is what I found on my M1 MacBook Pro:
Anthony's 1.4 SNOMED model pack:
- CDB hashed: 140 (±2)s
- Using cached CDB hash: <0.001s (i.e <1ms)

UMLS model pack:
- CDB hashed: 690 (±70)s
- Using cached CDB hash: ~12s

So there seems to be significant performance boost.
On the UMLS side, most of the 12s is spent hashing the config (pretty much all of it, I checked). More specifically, on hashing the `config.linking.filters` (around 8s); it contains all the CUIs within the model.
