### PR TITLE
CU-862j0jcdu / CU-862j0jd2n Cdb json

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -205,7 +205,7 @@ class CAT(object):
             logger.warning("Please consider updating [description, performance, location, ontology] in cat.config.version")
 
     def create_model_pack(self, save_dir_path: str, model_pack_name: str = DEFAULT_MODEL_PACK_NAME,
-            format: str = 'dill') -> str:
+            cdb_format: str = 'dill') -> str:
         """Will crete a .zip file containing all the models in the current running instance
         of MedCAT. This is not the most efficient way, for sure, but good enough for now.
 
@@ -214,8 +214,8 @@ class CAT(object):
                 An id will be appended to this name
             model_pack_name (str, optional):
                 The model pack name. Defaults to DEFAULT_MODEL_PACK_NAME.
-            format (str):
-                The format of the saved model pack.
+            cdb_format (str):
+                The format of the saved CDB in the model pack.
                 The available formats are:
                 - dill
                 - json
@@ -236,11 +236,11 @@ class CAT(object):
         save_dir_path = os.path.join(save_dir_path, model_pack_name)
 
         # Check format
-        if format.lower() == 'json':
+        if cdb_format.lower() == 'json':
             json_path = save_dir_path # in the same folder!
         else:
             json_path = None # use dill formating
-        logger.info('Saving model pack with %s format', format)
+        logger.info('Saving model pack with CDB in %s format', cdb_format)
 
         # expand user path to make this work with '~'
         os.makedirs(os.path.expanduser(save_dir_path), exist_ok=True)

--- a/medcat/utils/saving/converter.py
+++ b/medcat/utils/saving/converter.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def run_conversion(modelpack: str, format: str, target: str, overwrite: bool) -> None:
     cat = CAT.load_model_pack(modelpack)
     cat.create_model_pack(os.path.dirname(
-        target), os.path.basename(target), format=format)
+        target), os.path.basename(target), cdb_format=format)
 
 
 def main():

--- a/medcat/utils/saving/serializer.py
+++ b/medcat/utils/saving/serializer.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 __SPECIALITY_NAMES_CUI = set(["cui2names", "cui2snames", "cui2type_ids"])
 __SPECIALITY_NAMES_NAME = set(
     ["name2cuis", "name2cuis2status", "name_isupper"])
-__SPECIALITY_NAMES_OTHER = set(["snames"])
+__SPECIALITY_NAMES_OTHER = set(["snames", "addl_info"])
 SPECIALITY_NAMES = __SPECIALITY_NAMES_CUI | __SPECIALITY_NAMES_NAME | __SPECIALITY_NAMES_OTHER
 
 

--- a/medcat/utils/saving/serializer.py
+++ b/medcat/utils/saving/serializer.py
@@ -101,6 +101,7 @@ class CDBSerializer:
         - cui2snames
         - cui2type_ids
         - name_isupper
+        - addl_info
     These are specified at the top of the module (in `SPECIALITY_NAMES`).
 
     The rest of the information (i.e config and other less memory intensive parts) will

--- a/tests/utils/saving/test_serialization.py
+++ b/tests/utils/saving/test_serialization.py
@@ -76,7 +76,7 @@ class ModelCreationTests(unittest.TestCase):
 
     def test_dill_to_json(self):
         model_pack_path = self.undertest.create_model_pack(
-            self.json_model_pack.name, format='json')
+            self.json_model_pack.name, cdb_format='json')
         model_pack_folder = os.path.join(
             self.json_model_pack.name, model_pack_path)
         json_path = os.path.join(model_pack_folder, "*.json")


### PR DESCRIPTION
The CDB json formatting had some issues:
 - the naming through model pack creation would suggest that the model is saved as JSON while only (part of) the CDB was saved as JSON
 - The `addl_info` was not included

This PR fixes the above two issues:
- Change formatting parameter in model pack creation
  - Since it only affected CDB, made it `cdb_format` (previously just `format`)
- Add `addl_info` to CDB _json_ format

