### PR TITLE
Add options for loading meta models and additional NERs

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -300,7 +300,11 @@ class CAT(object):
         return model_pack_name
 
     @classmethod
-    def load_model_pack(cls, zip_path: str, meta_cat_config_dict: Optional[Dict] = None) -> "CAT":
+    def load_model_pack(cls,
+                        zip_path: str,
+                        meta_cat_config_dict: Optional[Dict] = None,
+                        load_meta_models: bool = True,
+                        load_addl_ner: bool = True) -> "CAT":
         """Load everything within the 'model pack', i.e. the CDB, config, vocab and any MetaCAT models
         (if present)
 
@@ -311,6 +315,10 @@ class CAT(object):
                 A config dict that will overwrite existing configs in meta_cat.
                 e.g. meta_cat_config_dict = {'general': {'device': 'cpu'}}.
                 Defaults to None.
+            load_meta_models (bool):
+                Whether to load MetaCAT models if present (Default value True).
+            load_addl_ner (bool):
+                Whether to load additional NER models if present (Default value True).
         """
         from medcat.cdb import CDB
         from medcat.vocab import Vocab
@@ -347,7 +355,7 @@ class CAT(object):
             vocab = None
 
         # Find meta models in the model_pack
-        trf_paths = [os.path.join(model_pack_path, path) for path in os.listdir(model_pack_path) if path.startswith('trf_')]
+        trf_paths = [os.path.join(model_pack_path, path) for path in os.listdir(model_pack_path) if path.startswith('trf_')] if load_addl_ner else []
         addl_ner = []
         for trf_path in trf_paths:
             trf = TransformersNER.load(save_dir_path=trf_path)
@@ -355,7 +363,7 @@ class CAT(object):
             addl_ner.append(trf)
 
         # Find meta models in the model_pack
-        meta_paths = [os.path.join(model_pack_path, path) for path in os.listdir(model_pack_path) if path.startswith('meta_')]
+        meta_paths = [os.path.join(model_pack_path, path) for path in os.listdir(model_pack_path) if path.startswith('meta_')] if load_meta_models else []
         meta_cats = []
         for meta_path in meta_paths:
             meta_cats.append(MetaCAT.load(save_dir_path=meta_path,

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -30,8 +30,7 @@ class CATTests(unittest.TestCase):
         cls.cdb.config.linking.disamb_length_limit = 5
         cls.cdb.config.general.full_unlink = True
         cls.meta_cat_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp")
-        cls.meta_cat = _get_meta_cat(cls.meta_cat_dir)
-        cls.undertest = CAT(cdb=cls.cdb, config=cls.cdb.config, vocab=cls.vocab, meta_cats=[cls.meta_cat])
+        cls.undertest = CAT(cdb=cls.cdb, config=cls.cdb.config, vocab=cls.vocab, meta_cats=[])
         cls._linkng_filters = cls.undertest.config.linking.filters.copy_of()
 
     @classmethod
@@ -349,7 +348,8 @@ class CATTests(unittest.TestCase):
 
     def test_create_model_pack(self):
         save_dir_path = tempfile.TemporaryDirectory()
-        full_model_pack_name = self.undertest.create_model_pack(save_dir_path.name, model_pack_name="mp_name")
+        cat = CAT(cdb=self.cdb, config=self.cdb.config, vocab=self.vocab, meta_cats=[_get_meta_cat(self.meta_cat_dir)])
+        full_model_pack_name = cat.create_model_pack(save_dir_path.name, model_pack_name="mp_name")
         pack = [f for f in os.listdir(save_dir_path.name)]
         self.assertTrue(full_model_pack_name in pack)
         self.assertTrue(f'{full_model_pack_name}.zip' in pack)
@@ -364,15 +364,19 @@ class CATTests(unittest.TestCase):
 
     def test_load_model_pack(self):
         save_dir_path = tempfile.TemporaryDirectory()
-        full_model_pack_name = self.undertest.create_model_pack(save_dir_path.name, model_pack_name="mp_name")
+        meta_cat = _get_meta_cat(self.meta_cat_dir)
+        cat = CAT(cdb=self.cdb, config=self.cdb.config, vocab=self.vocab, meta_cats=[meta_cat])
+        full_model_pack_name = cat.create_model_pack(save_dir_path.name, model_pack_name="mp_name")
         cat = self.undertest.load_model_pack(os.path.join(save_dir_path.name, f"{full_model_pack_name}.zip"))
         self.assertTrue(isinstance(cat, CAT))
         self.assertIsNotNone(cat.config.version.medcat_version)
-        self.assertEqual(repr(cat._meta_cats), repr([self.meta_cat]))
+        self.assertEqual(repr(cat._meta_cats), repr([meta_cat]))
 
     def test_load_model_pack_without_meta_cat(self):
         save_dir_path = tempfile.TemporaryDirectory()
-        full_model_pack_name = self.undertest.create_model_pack(save_dir_path.name, model_pack_name="mp_name")
+        meta_cat = _get_meta_cat(self.meta_cat_dir)
+        cat = CAT(cdb=self.cdb, config=self.cdb.config, vocab=self.vocab, meta_cats=[meta_cat])
+        full_model_pack_name = cat.create_model_pack(save_dir_path.name, model_pack_name="mp_name")
         cat = self.undertest.load_model_pack(os.path.join(save_dir_path.name, f"{full_model_pack_name}.zip"), load_meta_models=False)
         self.assertTrue(isinstance(cat, CAT))
         self.assertIsNotNone(cat.config.version.medcat_version)
@@ -389,7 +393,7 @@ def _get_meta_cat(meta_cat_dir):
     config = ConfigMetaCAT()
     config.general["category_name"] = "Status"
     config.train["nepochs"] = 1
-    config.model["input_size"] = 100
+    config.model["input_size"] = 10
     meta_cat = MetaCAT(tokenizer=TokenizerWrapperBERT(AutoTokenizer.from_pretrained("prajjwal1/bert-tiny")),
                        embeddings=None,
                        config=config)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -389,7 +389,8 @@ def _get_meta_cat(meta_cat_dir):
     config = ConfigMetaCAT()
     config.general["category_name"] = "Status"
     config.train["nepochs"] = 1
-    meta_cat = MetaCAT(tokenizer=TokenizerWrapperBERT(AutoTokenizer.from_pretrained("bert-base-uncased")),
+    config.model["input_size"] = 100
+    meta_cat = MetaCAT(tokenizer=TokenizerWrapperBERT(AutoTokenizer.from_pretrained("prajjwal1/bert-tiny")),
                        embeddings=None,
                        config=config)
     os.makedirs(meta_cat_dir, exist_ok=True)
@@ -398,5 +399,5 @@ def _get_meta_cat(meta_cat_dir):
     return meta_cat
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_meta_cat.py
+++ b/tests/test_meta_cat.py
@@ -9,7 +9,7 @@ from medcat.config_meta_cat import ConfigMetaCAT
 from medcat.tokenizers.meta_cat_tokenizers import TokenizerWrapperBERT
 
 
-class CATTests(unittest.TestCase):
+class MetaCATTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(self) -> None:
@@ -28,17 +28,14 @@ class CATTests(unittest.TestCase):
         self.tmp_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp")
         os.makedirs(self.tmp_dir, exist_ok=True)
 
-
     def tearDown(self) -> None:
         shutil.rmtree(self.tmp_dir)
-
 
     def test_train(self):
         json_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources', 'mct_export_for_meta_cat_test.json')
         results = self.meta_cat.train(json_path, save_dir_path=self.tmp_dir)
 
         self.assertEqual(results['report']['weighted avg']['f1-score'], 1.0)
-
 
     def test_save_load(self):
         json_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources', 'mct_export_for_meta_cat_test.json')

--- a/tests/test_meta_cat.py
+++ b/tests/test_meta_cat.py
@@ -13,15 +13,11 @@ class MetaCATTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(self) -> None:
-        tokenizer = TokenizerWrapperBERT(AutoTokenizer.from_pretrained("bert-base-uncased"))
+        tokenizer = TokenizerWrapperBERT(AutoTokenizer.from_pretrained('prajjwal1/bert-tiny'))
         config = ConfigMetaCAT()
         config.general['category_name'] = 'Status'
-        config.general['cntx_left'] = 15
-        config.general['cntx_right'] = 10
-        config.general['seed'] = 13
-        config.train['nepochs'] = 10
-        config.model['input_size'] = 300
-        config.train['auto_save_model'] = True
+        config.train['nepochs'] = 1
+        config.model['input_size'] = 100
 
         self.meta_cat = MetaCAT(tokenizer=tokenizer, embeddings=None, config=config)
 


### PR DESCRIPTION
This PR provides the options to switch on/off meta models and additional NER modes during the model pack loading. Before this, users had to prepare and maintain multiple model packs as variants to handle “on” and “off” use cases. After this, only one model pack is needed and the default behaviour is all enclosed models will be loaded. 