### PR TITLE
Reduce the false positives on pushing to test pypi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,3 +85,4 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
+        continue-on-error: true


### PR DESCRIPTION
This tiny PR tries to reduce the false-positive errors ("File already exists") from time to time on pushing to test pypi.