### PR TITLE
Make transformer_ner continue processing other entities after the first non-matching

### DIFF
--- a/medcat/ner/transformers_ner.py
+++ b/medcat/ner/transformers_ner.py
@@ -353,15 +353,15 @@ class TransformersNER(object):
                             # To not loop through everything
                             if end_char > r['end']:
                                 break
+                        if inds:
+                            entity = Span(doc, min(inds), max(inds) + 1, label=r['entity_group'])
+                            entity._.cui = r['entity_group']
+                            entity._.context_similarity = r['score']
+                            entity._.detected_name = r['word']
+                            entity._.id = len(doc._.ents)
+                            entity._.confidence = r['score']
 
-                        entity = Span(doc, min(inds), max(inds) + 1, label=r['entity_group'])
-                        entity._.cui = r['entity_group']
-                        entity._.context_similarity = r['score']
-                        entity._.detected_name = r['word']
-                        entity._.id = len(doc._.ents)
-                        entity._.confidence = r['score']
-
-                        doc._.ents.append(entity)
+                            doc._.ents.append(entity)
                     create_main_ann(self.cdb, doc)
                     if self.cdb.config.general['make_pretty_labels'] is not None:
                         make_pretty_labels(self.cdb, doc, LabelStyle[self.cdb.config.general['make_pretty_labels']])

--- a/tests/test_meta_cat.py
+++ b/tests/test_meta_cat.py
@@ -12,17 +12,17 @@ from medcat.tokenizers.meta_cat_tokenizers import TokenizerWrapperBERT
 class MetaCATTests(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self) -> None:
+    def setUpClass(cls) -> None:
         tokenizer = TokenizerWrapperBERT(AutoTokenizer.from_pretrained('prajjwal1/bert-tiny'))
         config = ConfigMetaCAT()
         config.general['category_name'] = 'Status'
         config.train['nepochs'] = 1
         config.model['input_size'] = 100
 
-        self.meta_cat = MetaCAT(tokenizer=tokenizer, embeddings=None, config=config)
+        cls.meta_cat = MetaCAT(tokenizer=tokenizer, embeddings=None, config=config)
 
-        self.tmp_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp")
-        os.makedirs(self.tmp_dir, exist_ok=True)
+        cls.tmp_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp")
+        os.makedirs(cls.tmp_dir, exist_ok=True)
 
     def tearDown(self) -> None:
         shutil.rmtree(self.tmp_dir)


### PR DESCRIPTION
Currently, `transformer_ner` stops processing as soon as the span of a recognised entity (e.g., a subword) does not match any text tokens so the other remaining entities won’t be inspected or added to the `Doc` object. This PR fixed that. 