### PR TITLE
Pin down transformers for the de-identification model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         'gensim>=4.3.0', # first to support 3.11
         'spacy>=3.1.0',
         'scipy~=1.9.2', # first to support 3.11
-        'transformers>=4.19.2',
+        'transformers>=4.19.2,<4.22.0',
         'torch>=1.13.0', # first to support 3.11
         'tqdm>=4.27',
         'scikit-learn>=1.1.3', # first to supporrt 3.11

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         'gensim>=4.3.0', # first to support 3.11
         'spacy>=3.1.0',
         'scipy~=1.9.2', # first to support 3.11
-        'transformers>=4.19.2,<4.22.0',
+        'transformers>=4.19.2,<4.22.0', # upper bound is needed for the de-id model until it is retrained
         'torch>=1.13.0', # first to support 3.11
         'tqdm>=4.27',
         'scikit-learn>=1.1.3', # first to supporrt 3.11


### PR DESCRIPTION
The recent release 1.7.0 has caused the de-id model to throw the following error:
> AttributeError: 'RobertaTokenizerFast' object has no attribute '_in_target_context_manager'

This PR temporarily pins down the dependency as a stopgap measure until a new base model can be trained with the newer release of transformers.