### PR TITLE
CU-862jr8wkk Pin pydantic dependency to avoid conflicts with v2.0 (#318)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
         'xxhash>=3.0.0', # allow later versions, tested with 3.1.0
         'blis>=0.7.5', # allow later versions, tested with 0.7.9
         'click>=8.0.4', # allow later versions, tested with 8.1.3
-        'pydantic>=1.10.0', # for spacy compatibility
+        'pydantic>=1.10.0,<2.0', # for spacy compatibility; avoid 2.0 due to breaking changes
         # the following are not direct dependencies of MedCAT but needed for docs/building
         # hopefully will no longer need the transitive dependencies
         'aiohttp==3.8.3', # 3.8.3 is needed for compatibility with fsspec <- datasets <- medcat


### PR DESCRIPTION
The readthedocs builds were failing again.
This time the reason was the pydantic version that was installed was the 2.0 alpha and that wasn't compatible with other dependencies.

Pinned pydantic version to less than 2 - it'll have some breaking changes anyway.

Temporarily changed the target for doc builds to confirm that the fix works.