### PR TITLE
Add option to add synthetic csv data in cat.supervise_train() and meta_cat.train()

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -912,8 +912,8 @@ class CAT(object):
             checkpoint (Optional[Optional[medcat.utils.checkpoint.CheckpointST]):
                 The MedCAT CheckpointST object
             synthetic_data_path (Optional[str])
-                the path to a csv file that contains synthetic data that can be added to the training data in the format
-                [name, cui, start, end]
+                the path to a CSV file that contains synthetic data with the columns {name, cui, start, end}
+                which can be added to the training set
             retain_filters (bool):
                 If True, retain the filters in the MedCATtrainer export within this CAT instance. In other words, the
                 filters defined in the input file will henseforth be saved within config.linking.filters .
@@ -1050,6 +1050,7 @@ class CAT(object):
 
                 if synthetic_data_path is not None:
                     synth_data = pd.read_csv(synthetic_data_path)
+                    assert {'cui', 'name', 'start', 'end'}.issubset(synth_data.columns)
                     logger.info(
                         f"Training with additional {len(synth_data)} synthetic data points from {synthetic_data_path}"
                     )

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -2,9 +2,9 @@ import os
 import json
 import logging
 
-import pandas as pd
 import torch
 import numpy
+import pandas as pd
 from multiprocessing import Lock
 from torch import nn, Tensor
 from spacy.tokens import Doc
@@ -108,8 +108,8 @@ class MetaCAT(PipeRunner):
             json_path (Union[str, list]):
                 Path/Paths to a MedCATtrainer export containing the meta_annotations we want to train for.
             synthetic_csv_path (Optional[str]):
-                Path to a csv file containing synthetically generated data that can be added to the training data in the
-                format [name, cui, start, end, label1, label2 [...])
+                Path to a csv file containing synthetically generated data that can be added to the training data with
+                 the headings {text, cui, start, end, category_name1, category_name2 [...]}
             save_dir_path (Optional[str]):
                 In case we have aut_save_model (meaning during the training the best model will be saved)
                 we need to set a save path. Defaults to `None`.
@@ -162,6 +162,7 @@ class MetaCAT(PipeRunner):
 
         if synthetic_csv_path is not None:
             synth_data_loaded = pd.read_csv(synthetic_csv_path)
+            assert {'text', 'cui', 'start', 'end'}.issubset(synth_data_loaded.columns)
             logger.info(
                 f"Training with additional {len(synth_data_loaded)} synthetic data points from {synthetic_csv_path}"
             )

--- a/medcat/utils/meta_cat/data_utils.py
+++ b/medcat/utils/meta_cat/data_utils.py
@@ -118,6 +118,28 @@ def prepare_from_csv(
         replace_center: Optional[str] = None,
         lowercase: bool = True,
 ) -> Dict:
+    """Convert the synthetic data from a CSV format into a format for training. This is just a modified
+    version of prepare_from_json().
+    Args:
+        data (pd.DataFrame):
+            Loaded synthetic data from CSV file - pd.load_csv(<synthetic_data_csv>).
+             Example: {'text':['<text>', ...], 'cui':['<cui>', ...], 'start':['<start>', ...],
+             'end':['<end>', ...], 'category_name':['<category_value>', ...], ...}
+        cntx_left (int):
+            Size of context to get from the left of the concept
+        cntx_right (int):
+            Size of context to get from the right of the concept
+        tokenizer (medcat.tokenizers.meta_cat_tokenizers):
+            Something to split text into tokens for the LSTM/BERT/whatever meta models.
+        replace_center (Optional[str]):
+            If not None the center word (concept) will be replaced with whatever this is.
+        lowercase (bool):
+            Should the text be lowercased before tokenization. Defaults to True.
+
+    Returns:
+        out_data (dict):
+            Example: {'category_name': [('<category_value>', '<[tokens]>', '<center_token>'), ...], ...}
+    """
     out_data: Dict = {}
 
     for i in range(len(data)):
@@ -235,7 +257,7 @@ class Span(object):
         self.start_char = start_char
         self.end_char = end_char
         self._.id = id_  # type: ignore
-        self._.meta_anns = None  # type: ignore
+        self._.meta_anns = None # type: ignore
 
 
 class Doc(object):

--- a/tests/resources/synthetic_train_data.csv
+++ b/tests/resources/synthetic_train_data.csv
@@ -1,0 +1,41 @@
+text,cui,name,start,end,Status
+no hist of sympathetic nervous structure injury,282747005,sympathetic nervous structure injury,11,47,Other
+agenesis of nasal bone when 30 yr o,1003577003,agenesis of nasal bone,0,22,Affirmed
+previous acute skin sarcoidosis,238674006,acute skin sarcoidosis,9,31,Affirmed
+infectious disease of abdomen last 7 month,128070006,infectious disease of abdomen,0,29,Affirmed
+no ph of cannabis poisoning,1149328002,cannabis poisoning,9,27,Other
+prev acute myocarditis - tuberculous,194949003,acute myocarditis - tuberculous,5,36,Affirmed
+previous hx of exotropia of bilateral eyes,1.56326910001191E+016,exotropia of bilateral eyes,15,42,Affirmed
+past medical history of hypertrophy of gallbladder,76875008,hypertrophy of gallbladder,24,50,Affirmed
+laceration of right buttock last 3 month,1.09045110001191E+016,laceration of right buttock,0,27,Affirmed
+several acute pyelitis,32801008,acute pyelitis,8,22,Affirmed
+accidental chlorprothixene overdose suspected,427131001,accidental chlorprothixene overdose,0,35,Affirmed
+suspicion of sprain of shoulder,3199001,sprain of shoulder,13,31,Affirmed
+pos nutritional myopathy,44253006,nutritional myopathy,4,24,Affirmed
+probably bee sting-induced anaphylaxis,241931004,bee sting-induced anaphylaxis,9,38,Affirmed
+apolipoprotein a-i deficiency suspected,238095002,apolipoprotein a-i deficiency,0,29,Affirmed
+maybe adenocarcinoma of bladder,255110003,adenocarcinoma of bladder,6,31,Affirmed
+possible fecal peritonitis,235985005,fecal peritonitis,9,26,Affirmed
+suspect lymph fistula,234105001,lymph fistula,8,21,Affirmed
+susp microcephaly-oculo-digito-esophageal-duodenal syndrome,702431004,microcephaly-oculo-digito-esophageal-duodenal syndrome,5,59,Affirmed
+could be primary immune deficiency disorder,58606001,primary immune deficiency disorder,9,43,Affirmed
+explained about postsurgical menopause,371036001,postsurgical menopause,16,38,Affirmed
+sisters primary syphilis of nipple,237447001,primary syphilis of nipple,8,34,Affirmed
+sibling feels infection caused by gigantocotyle,55065004,infection caused by gigantocotyle,14,47,Affirmed
+family hist bacterial keratitis,314557000,bacterial keratitis,12,31,Affirmed
+husbands leukemic infiltration of skin,404156009,leukemic infiltration of skin,9,38,Affirmed
+sisters has macrosaccadic oscillations,307689000,macrosaccadic oscillations,12,38,Affirmed
+non-diabetic hypoglycemic coma risk score,230796005,non-diabetic hypoglycemic coma,0,30,Affirmed
+discussed intentional flunitrazepam overdose,296056007,intentional flunitrazepam overdose,10,44,Affirmed
+worried elephantiasis of upper eyelid,700337008,elephantiasis of upper eyelid,8,37,Affirmed
+fhx heterophil-negative mononucleosis syndrome,65230006,heterophil-negative mononucleosis syndrome,4,46,Affirmed
+absence of signs and symptoms of disorder of extraembryonic membrane,609522002,disorder of extraembryonic membrane,33,68,Other
+traumatic intracranial subdural hematoma none,262952002,traumatic intracranial subdural hematoma,0,40,Other
+absence of injury of finger,52011008,injury of finger,11,27,Other
+denied conjunctival abrasion,609362004,conjunctival abrasion,7,28,Other
+intentional netilmicin poisoning not detected,291490007,intentional netilmicin poisoning,0,32,Other
+chronic peptic ulcer none,128287004,chronic peptic ulcer,0,20,Other
+absent miscarriage complicated by shock,34270000,miscarriage complicated by shock,7,39,Other
+no haff syndrome,359569009,haff syndrome,3,16,Other
+absence of signs and symptoms of disease caused by neisseria,409790005,disease caused by neisseria,33,60,Other
+cryptococcal chorioretinitis negative,416877003,cryptococcal chorioretinitis,0,28,Other

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -230,6 +230,30 @@ class CATTests(unittest.TestCase):
         for step in range(1, nepochs * num_of_documents + 1):
             self.assertTrue(f"checkpoint-1-{step}" in checkpoints)
 
+    def test_train_supervised_with_synthetic_data(self):
+        nepochs = 3
+        num_of_documents = 27
+        data_path = os.path.join(os.path.dirname(__file__), "resources", "medcat_trainer_export.json")
+        synthetic_data_path = os.path.join(os.path.dirname(__file__), "resources", "synthetic_train_data.csv")
+        ckpt_dir_path = tempfile.TemporaryDirectory().name
+        checkpoint = Checkpoint(dir_path=ckpt_dir_path, steps=1, max_to_keep=sys.maxsize)
+        fp, fn, tp, p, r, f1, cui_counts, examples = self.undertest.train_supervised(data_path,
+                                                                                     synthetic_data_path=synthetic_data_path,
+                                                                                     checkpoint=checkpoint,
+                                                                                     nepochs=nepochs)
+        checkpoints = [f for f in os.listdir(ckpt_dir_path) if "checkpoint-" in f]
+        self.assertEqual({}, fp)
+        self.assertEqual({}, fn)
+        self.assertEqual({}, tp)
+        self.assertEqual({}, p)
+        self.assertEqual({}, r)
+        self.assertEqual({}, f1)
+        self.assertEqual({}, cui_counts)
+        self.assertEqual({}, examples)
+        self.assertEqual(nepochs * num_of_documents, len(checkpoints))
+        for step in range(1, nepochs * num_of_documents + 1):
+            self.assertTrue(f"checkpoint-1-{step}" in checkpoints)
+
     def test_resume_supervised_training(self):
         nepochs_train = 1
         nepochs_retrain = 2

--- a/tests/test_meta_cat.py
+++ b/tests/test_meta_cat.py
@@ -33,6 +33,13 @@ class MetaCATTests(unittest.TestCase):
 
         self.assertEqual(results['report']['weighted avg']['f1-score'], 1.0)
 
+    def test_train_with_synthetic_data(self):
+        json_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources', 'mct_export_for_meta_cat_test.json')
+        synthetic_data_path = os.path.join(os.path.dirname(__file__), "resources", "synthetic_train_data.csv")
+        results = self.meta_cat.train(json_path, save_dir_path=self.tmp_dir, synthetic_csv_path=synthetic_data_path)
+
+        self.assertAlmostEquals(results['report']['weighted avg']['f1-score'], 1.0, places=1)
+
     def test_save_load(self):
         json_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources', 'mct_export_for_meta_cat_test.json')
         self.meta_cat.train(json_path, save_dir_path=self.tmp_dir)


### PR DESCRIPTION
Allow the option to add synthetic data to `cat` supervised training and `meta_cat` training from a CSV file that contains:
```
text, cui, name, start, end, [category_name]
``` 