### PR TITLE
CU-863gntc58 Umlspt2ch

### DIFF
--- a/medcat/utils/preprocess_umls.py
+++ b/medcat/utils/preprocess_umls.py
@@ -3,7 +3,7 @@ from typing import List, Union
 import pandas as pd
 import tqdm
 import os
-from typing import Dict, Set, List
+from typing import Dict, Set
 
 _DEFAULT_COLUMNS: list = [
     "CUI",
@@ -245,9 +245,9 @@ class UMLS:
             cur_cui = row['CUI']
             paui = row['PAUI']
             parent_cui = aui_cui[paui]
-            if cur_cui not in pt2ch:
-                pt2ch[cur_cui] = set()
-            pt2ch[cur_cui].add(parent_cui)
+            if parent_cui not in pt2ch:
+                pt2ch[parent_cui] = set()
+            pt2ch[parent_cui].add(cur_cui)
         # move from set to list for consistency with SNOMED
         pt2ch: Dict[str, List[str]] = pt2ch  # type: ignore
         for k, v in pt2ch.items():

--- a/medcat/utils/preprocess_umls.py
+++ b/medcat/utils/preprocess_umls.py
@@ -245,14 +245,15 @@ class UMLS:
             cur_cui = row['CUI']
             paui = row['PAUI']
             parent_cui = aui_cui[paui]
+            # avoid self as parent/child
+            if parent_cui == cur_cui:
+                continue
             if parent_cui not in pt2ch:
                 pt2ch[parent_cui] = set()
             pt2ch[parent_cui].add(cur_cui)
         # move from set to list for consistency with SNOMED
         pt2ch: Dict[str, List[str]] = pt2ch  # type: ignore
         for k, v in pt2ch.items():
-            if k in v:
-                v.remove(k)
             pt2ch[k] = list(v)
         return pt2ch
 

--- a/medcat/utils/preprocess_umls.py
+++ b/medcat/utils/preprocess_umls.py
@@ -3,6 +3,7 @@ from typing import List, Union
 import pandas as pd
 import tqdm
 import os
+from typing import Dict, Set, List
 
 _DEFAULT_COLUMNS: list = [
     "CUI",
@@ -239,7 +240,7 @@ class UMLS:
         cui_parent = cui_parent[cui_parent['PAUI'].notna()]
 
         # create dict
-        pt2ch: dict[str, set[str]] = {}
+        pt2ch: Dict[str, Set[str]] = {}
         for _, row in tqdm.tqdm(cui_parent.iterrows(), total=len(cui_parent.index)):
             cur_cui = row['CUI']
             paui = row['PAUI']
@@ -247,6 +248,8 @@ class UMLS:
             if cur_cui not in pt2ch:
                 pt2ch[cur_cui] = set()
             pt2ch[cur_cui].add(parent_cui)
+        # move from set to list for consistency with SNOMED
+        pt2ch: Dict[str, List[str]] = pt2ch  # type: ignore
         for k, v in pt2ch.items():
             if k in v:
                 v.remove(k)

--- a/medcat/utils/preprocess_umls.py
+++ b/medcat/utils/preprocess_umls.py
@@ -245,6 +245,8 @@ class UMLS:
                 pt2ch[cur_cui] = set()
             pt2ch[cur_cui].add(parent_cui)
         for k, v in pt2ch.items():
+            if k in v:
+                v.remove(k)
             pt2ch[k] = list(v)
         return pt2ch
 
@@ -272,11 +274,17 @@ if __name__ == '__main__':
     pt2ch = umls.get_pt2ch()
     print('Get parent-child dict', len(pt2ch),
           '' if len(pt2ch) > 1_000 else pt2ch)
+    all_vals = [len(v) for v in pt2ch.values()]
+    print('LEN of VALS:', sum(all_vals), 'max',
+          max(all_vals), 'min', min(all_vals), 'mean', sum(all_vals) / len(all_vals))
     import random
     random_4_keys = random.sample(list(pt2ch.keys()), k=4)
 
     def _get_name(cui: str) -> str:
-        return df[df['cui'] == cui]['name'].iloc[0]
+        matches = df[df['cui'] == cui]
+        if len(matches.index) == 0:
+            return 'N/A'  # UNKNOWN
+        return matches['name'].iloc[0]
     print('FF RAW   ', [f"{k}:{pt2ch[k]}" for k in random_4_keys])
     print('FIRST FEW', [
         (f"{_get_name(key)} ({key})", [f"{_get_name(child)} ({child})" for child in pt2ch[key]]) for key in random_4_keys])

--- a/medcat/utils/preprocess_umls.py
+++ b/medcat/utils/preprocess_umls.py
@@ -224,6 +224,9 @@ class UMLS:
         # create a AUI -> CUI map
         aui_cui = dict(zip(conso_df["AUI"], conso_df["CUI"]))
 
+        # remove non-preferred from conso
+        conso_df = conso_df[conso_df['ISPREF'] == 'Y']
+
         # filter ISA relationships
         hier_df = hier_df[hier_df['RELA'] == 'isa']
 

--- a/medcat/utils/preprocess_umls.py
+++ b/medcat/utils/preprocess_umls.py
@@ -187,6 +187,23 @@ class UMLS:
         return df
 
     def get_pt2ch(self) -> dict:
+        """Generates a parent to children dict.
+
+        It goes through all the < # TODO
+
+        The resulting dictionary maps a CUI to a list of CUIs that
+        consider that CUI as their parent.
+
+        PS:
+        This expects the MRHIER.RRF file to also exist in the same folder
+        as the MRCONSO.RRF file.
+
+        Raises:
+            ValueError: If the MRHIER.RRF file wasn't found
+
+        Returns:
+            dict: The dictionary of parent CUI and their children.
+        """
         path = self.main_file_name.rsplit('/', 1)[0]
         hier_file = f"{path}/MRHIER.RRF"
 
@@ -204,11 +221,14 @@ class UMLS:
         if self.allow_langugages:
             conso_df = conso_df[conso_df["LAT"].isin(self.allow_langugages)]
 
+        # create a AUI -> CUI map
+        aui_cui = dict(zip(conso_df["AUI"], conso_df["CUI"]))
+
+        # filter ISA relationships
+        hier_df = hier_df[hier_df['RELA'] == 'isa']
+
         # merge dataframes
         merged_df = pd.merge(conso_df, hier_df, on=['AUI', 'CUI'])
-
-        # create a AUI -> CUI map
-        aui_cui = dict(zip(merged_df["AUI"], merged_df["CUI"]))
 
         # only keep CUI and parent AUI
         cui_parent = merged_df[['CUI', 'PAUI']]


### PR DESCRIPTION
UMLS preprocessing script did not previously have a way to generate a parent to children mapping which was present in the SNOMED preprocessing script.

This PR adds a method for that mapping.

PS:
UMLS has circular hierarchies ([source](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2243677/pdf/procamiasymp00002-0096.pdf)). As such, so do these mappings. So if a user needs these not to exist, they'd need to preprocess the map.
This also means that getting all children recursively is not possible from the default mapping.
