### PR TITLE
Fix for Issue 325

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -1526,7 +1526,7 @@ class CAT(object):
                         logger.warning(str(e))
         sleep(2)
 
-    def _add_nested_ent(self, doc: Doc, _ents: list, _ent) -> None:
+    def _add_nested_ent(self, doc: Doc, _ents: List[Span], _ent) -> None:
         meta_anns = None
         start = _ent.start
         end = _ent.end
@@ -1559,7 +1559,7 @@ class CAT(object):
         if doc is not None:
             out_ent: Dict = {}
             if self.config.general.show_nested_entities:
-                _ents = []
+                _ents: List[Span] = []
                 for _ent in doc._.ents:
                     self._add_nested_ent(doc, _ents, _ent)
             else:


### PR DESCRIPTION
Fixing `config.general.show_nested_entities = True` issue reported in issue #325.

What the PR does is use the new API that spacy provides.
It also detects the spacy version and uses a different path for older versions.

I've checked and it seems to be working with spacy versions between 3.1.3 and 3.4.4.

Though the testing hasn't been too rigorous.

PS:
The main issue with this PR is the fact that I'm not catching the issue in an automated test. I was unable to find a test string that would get to this part of the code. None of the existing examples (nor the ones I could come up with myself) reach the relevant part even if `config.general.show_nested_entities = True`  is set. So if someone has an idea, that'd be a great addition.