### PR TITLE
CU-86785yhfk Add method to populate cui2snames with data from cui2names

### DIFF
--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -533,6 +533,27 @@ class CDB(object):
         self.reset_concept_similarity()
         self.is_dirty = True
 
+    def populate_cui2snames(self, force: bool = True) -> None:
+        """Populate the cui2snames dict if it's empty.
+
+        If the dict is not empty and the population is not force,
+        nothing will happen.
+
+        For now, this method simply populates all the names form
+        cui2names into cui2snames.
+
+        Args:
+            force (bool, optional): Whether to force the (re-)population. Defaults to True.
+        """
+        if not force and self.cui2snames:
+            return
+        self.cui2snames.clear() # in case forced re-population
+        # run through cui2names
+        # and create new sets so that they can be independently modified
+        for cui, names in self.cui2names.items():
+            self.cui2snames[cui] = set(names)  # new set
+        self.is_dirty = True
+
     def filter_by_cui(self, cuis_to_keep: Union[List[str], Set[str]]) -> None:
         """Subset the core CDB fields (dictionaries/maps). Note that this will potenitally keep a bit more CUIs
         then in cuis_to_keep. It will first find all names that link to the cuis_to_keep and then

--- a/tests/test_cdb.py
+++ b/tests/test_cdb.py
@@ -75,5 +75,12 @@ class CDBTests(unittest.TestCase):
         assert 'C0000039' not in self.undertest.name2cuis['virus~z']
         assert 'C0000039' not in self.undertest.name2cuis2status['virus~z']
 
+    def test_cui2snames_population(self):
+        self.undertest.cui2snames.clear()
+        self.undertest.populate_cui2snames()
+        for cui in self.undertest.cui2names:
+            with self.subTest(cui):
+                self.assertIn(cui, self.undertest.cui2snames)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is an attempt to allow subsetting of smaller models as well.

In reference to:
https://discourse.cogstack.org/t/advice-on-medcat-for-a-small-set-of-concepts/216

Best I can tell, the only reason the `CDB.filter_by_cui` method fails upon an empty `cui2snames` is because it excpect all CUIs to have snames filled in as well and the method would thus throw an exception otherwise.

Though if someone knows of other reasons, I'd be happy to hear them.