### PR TITLE
CU-862k1tt90 Fix circular imports by moving raw deid method back to helpers module

### DIFF
--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -111,34 +111,3 @@ class DeIdModel(NerModel):
             return f"Incorrect number of addl_ner: {len(cat._addl_ner)}"
         return ""
 
-
-# For now, we will keep this method separate from the above class
-# This is so that we wouldn't need to create a thorwaway object
-# when calling the method from .helpers where it used to be.
-# After the deprecated method in .helpers is removed, we can
-# move this to a proper class method.
-def deid_text(cat: CAT, text: str, redact: bool = False) -> str:
-    """De-identify text.
-
-    De-identified text.
-    If redaction is enabled, identifiable entities will be
-    replaced with starts (e.g `*****`).
-    Otherwise, the replacement will be the CUI or in other words,
-    the type of information that was hidden (e.g [PATIENT]).
-
-
-    Args:
-        cat (CAT): The CAT object to use for deid.
-        text (str): The input document.
-        redact (bool, optional): Whether to redact. Defaults to False.
-
-    Returns:
-        str: The de-identified document.
-    """
-    new_text = str(text)
-    entities = cat.get_entities(text)['entities']
-    for ent in sorted(entities.values(), key=lambda ent: ent['start'], reverse=True):
-        r = "*"*(ent['end']-ent['start']
-                 ) if redact else cat.cdb.get_name(ent['cui'])
-        new_text = new_text[:ent['start']] + f'[{r}]' + new_text[ent['end']:]
-    return new_text

--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -39,6 +39,8 @@ from typing import Union, Tuple, Any
 from medcat.cat import CAT
 from medcat.utils.ner.model import NerModel
 
+from medcat.utils.ner.helpers import _deid_text as deid_text
+
 
 class DeIdModel(NerModel):
     """The DeID model.

--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -112,4 +112,3 @@ class DeIdModel(NerModel):
         if len(cat._addl_ner) != 1:
             return f"Incorrect number of addl_ner: {len(cat._addl_ner)}"
         return ""
-

--- a/medcat/utils/ner/helpers.py
+++ b/medcat/utils/ner/helpers.py
@@ -1,8 +1,39 @@
 from medcat.utils.data_utils import count_annotations
 from medcat.cdb import CDB
 
-from medcat.utils.ner.deid import deid_text as _deid_text
 from medcat.utils.decorators import deprecated
+
+
+# For now, we will keep this method separate from the above class
+# This is so that we wouldn't need to create a thorwaway object
+# when calling the method from .helpers where it used to be.
+# After the deprecated method in .helpers is removed, we can
+# move this to a proper class method.
+def _deid_text(cat, text: str, redact: bool = False) -> str:
+    """De-identify text.
+
+    De-identified text.
+    If redaction is enabled, identifiable entities will be
+    replaced with starts (e.g `*****`).
+    Otherwise, the replacement will be the CUI or in other words,
+    the type of information that was hidden (e.g [PATIENT]).
+
+
+    Args:
+        cat (CAT): The CAT object to use for deid.
+        text (str): The input document.
+        redact (bool, optional): Whether to redact. Defaults to False.
+
+    Returns:
+        str: The de-identified document.
+    """
+    new_text = str(text)
+    entities = cat.get_entities(text)['entities']
+    for ent in sorted(entities.values(), key=lambda ent: ent['start'], reverse=True):
+        r = "*"*(ent['end']-ent['start']
+                 ) if redact else cat.cdb.get_name(ent['cui'])
+        new_text = new_text[:ent['start']] + f'[{r}]' + new_text[ent['end']:]
+    return new_text
 
 
 @deprecated("API now allows creating a DeId model (medcat.utils.ner.deid.DeIdModel). "


### PR DESCRIPTION
It's weird that GHA (i.e tests) didn't catch this.
But every time I run the current master branch locally, I get a circular import issue.
E.g:
```
Traceback (most recent call last):
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT_2023_01_05/temp/negaccuracy/load_and_check.py", line 3, in <module>
    from medcat.cat import CAT
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT_2023_01_05/venv3.10/lib/python3.10/site-packages/medcat-1.2.9.dev334-py3.10.egg/medcat/cat.py", line 24, in <module>
    from medcat.pipe import Pipe
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT_2023_01_05/venv3.10/lib/python3.10/site-packages/medcat-1.2.9.dev334-py3.10.egg/medcat/pipe.py", line 19, in <module>
    from medcat.ner.transformers_ner import TransformersNER
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT_2023_01_05/venv3.10/lib/python3.10/site-packages/medcat-1.2.9.dev334-py3.10.egg/medcat/ner/transformers_ner.py", line 16, in <module>
    from medcat.utils.ner.metrics import metrics
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT_2023_01_05/venv3.10/lib/python3.10/site-packages/medcat-1.2.9.dev334-py3.10.egg/medcat/utils/ner/__init__.py", line 2, in <module>
    from .helpers import deid_text, make_or_update_cdb
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT_2023_01_05/venv3.10/lib/python3.10/site-packages/medcat-1.2.9.dev334-py3.10.egg/medcat/utils/ner/helpers.py", line 4, in <module>
    from medcat.utils.ner.deid import deid_text as _deid_text
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT_2023_01_05/venv3.10/lib/python3.10/site-packages/medcat-1.2.9.dev334-py3.10.egg/medcat/utils/ner/deid.py", line 39, in <module>
    from medcat.cat import CAT
ImportError: cannot import name 'CAT' from partially initialized module 'medcat.cat' (most likely due to a circular import) (/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT_2023_01_05/venv3.10/lib/python3.10/site-packages/medcat-1.2.9.dev334-py3.10.egg/medcat/cat.py)
```