### PR TITLE
Cu 863h30jyb separate train from data load

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -899,6 +899,55 @@ class CAT(object):
         Run supervised training on a dataset from MedCATtrainer in JSON format.
 
         Refer to `train_supervised_raw` for more details.
+        """
+        with open(data_path) as f:
+            data = json.load(f)
+        return self.train_supervised_raw(data, reset_cui_count, nepochs,
+                                         print_stats, use_filters, terminate_last,
+                                         use_overlaps, use_cui_doc_limit, test_size,
+                                         devalue_others, use_groups, never_terminate,
+                                         train_from_false_positives, extra_cui_filter,
+                                         retain_extra_cui_filter, checkpoint,
+                                         retain_filters, is_resumed)
+
+    def train_supervised_raw(self,
+                             data: Dict[str, List[Dict[str, dict]]],
+                             reset_cui_count: bool = False,
+                             nepochs: int = 1,
+                             print_stats: int = 0,
+                             use_filters: bool = False,
+                             terminate_last: bool = False,
+                             use_overlaps: bool = False,
+                             use_cui_doc_limit: bool = False,
+                             test_size: int = 0,
+                             devalue_others: bool = False,
+                             use_groups: bool = False,
+                             never_terminate: bool = False,
+                             train_from_false_positives: bool = False,
+                             extra_cui_filter: Optional[Set] = None,
+                             retain_extra_cui_filter: bool = False,
+                             checkpoint: Optional[Checkpoint] = None,
+                             retain_filters: bool = False,
+                             is_resumed: bool = False) -> Tuple:
+        """Train supervised based on the raw data provided.
+
+        The raw data is expected in the following format:
+        {'projects':
+            [ # list of projects
+                { # project 1
+                    'name': '<some name>',
+                    # list of documents
+                    'documents': [{'name': '<some name>',  # document 1
+                                    'text': '<text of the document>',
+                                    # list of annotations
+                                    'annotations': [{'start': -1,  # annotation 1
+                                                    'end': 1,
+                                                    'cui': 'cui',
+                                                    'value': '<text value>'}, ...],
+                                    }, ...]
+                }, ...
+            ]
+        }
 
         Please take care that this is more a simulated online training then supervised.
 
@@ -909,8 +958,8 @@ class CAT(object):
         extra_cui_filter ⊆ MCT filter ⊆ Model/config filter.
 
         Args:
-            data_path (str):
-                The path to the json file that we get from MedCATtrainer on export.
+            data (Dict[str, List[Dict[str, dict]]]):
+                The raw data, e.g from MedCATtrainer on export.
             reset_cui_count (boolean):
                 Used for training with weight_decay (annealing). Each concept has a count that is there
                 from the beginning of the CDB, that count is used for annealing. Resetting the count will
@@ -979,8 +1028,7 @@ class CAT(object):
         local_filters = self.config.linking.filters.copy_of()
 
         fp = fn = tp = p = r = f1 = examples = {}
-        with open(data_path) as f:
-            data = json.load(f)
+
         cui_counts = {}
 
         if retain_filters:

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -863,9 +863,44 @@ class CAT(object):
                          checkpoint: Optional[Checkpoint] = None,
                          retain_filters: bool = False,
                          is_resumed: bool = False) -> Tuple:
-        """TODO: Refactor, left from old
-        Run supervised training on a dataset from MedCATtrainer. Please take care that this is more a simulated
-        online training then supervised.
+        """Train supervised by reading data from a json file.
+
+        Refer to `train_supervvised_from_json` and/or `train_supervised_raw`
+        for further details.
+        """
+        return self.train_supervised_from_json(data_path, reset_cui_count, nepochs,
+                                               print_stats, use_filters, terminate_last,
+                                               use_overlaps, use_cui_doc_limit, test_size,
+                                               devalue_others, use_groups, never_terminate,
+                                               train_from_false_positives, extra_cui_filter,
+                                               retain_extra_cui_filter, checkpoint,
+                                               retain_filters, is_resumed)
+
+    def train_supervised_from_json(self,
+                                   data_path: str,
+                                   reset_cui_count: bool = False,
+                                   nepochs: int = 1,
+                                   print_stats: int = 0,
+                                   use_filters: bool = False,
+                                   terminate_last: bool = False,
+                                   use_overlaps: bool = False,
+                                   use_cui_doc_limit: bool = False,
+                                   test_size: int = 0,
+                                   devalue_others: bool = False,
+                                   use_groups: bool = False,
+                                   never_terminate: bool = False,
+                                   train_from_false_positives: bool = False,
+                                   extra_cui_filter: Optional[Set] = None,
+                                   retain_extra_cui_filter: bool = False,
+                                   checkpoint: Optional[Checkpoint] = None,
+                                   retain_filters: bool = False,
+                                   is_resumed: bool = False) -> Tuple:
+        """
+        Run supervised training on a dataset from MedCATtrainer in JSON format.
+
+        Refer to `train_supervised_raw` for more details.
+
+        Please take care that this is more a simulated online training then supervised.
 
         When filtering, the filters within the CAT model are used first,
         then the ones from MedCATtrainer (MCT) export filters,
@@ -939,33 +974,6 @@ class CAT(object):
             examples (dict):
                 FP/FN examples of sentences for each CUI.
         """
-        return self.train_supervised_from_json(data_path, reset_cui_count, nepochs,
-                                               print_stats, use_filters, terminate_last,
-                                               use_overlaps, use_cui_doc_limit, test_size,
-                                               devalue_others, use_groups, never_terminate,
-                                               train_from_false_positives, extra_cui_filter,
-                                               retain_extra_cui_filter, checkpoint,
-                                               retain_filters, is_resumed)
-
-    def train_supervised_from_json(self,
-                                   data_path: str,
-                                   reset_cui_count: bool = False,
-                                   nepochs: int = 1,
-                                   print_stats: int = 0,
-                                   use_filters: bool = False,
-                                   terminate_last: bool = False,
-                                   use_overlaps: bool = False,
-                                   use_cui_doc_limit: bool = False,
-                                   test_size: int = 0,
-                                   devalue_others: bool = False,
-                                   use_groups: bool = False,
-                                   never_terminate: bool = False,
-                                   train_from_false_positives: bool = False,
-                                   extra_cui_filter: Optional[Set] = None,
-                                   retain_extra_cui_filter: bool = False,
-                                   checkpoint: Optional[Checkpoint] = None,
-                                   retain_filters: bool = False,
-                                   is_resumed: bool = False) -> Tuple:
         checkpoint = self._init_ckpts(is_resumed, checkpoint)
 
         local_filters = self.config.linking.filters.copy_of()

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -842,6 +842,8 @@ class CAT(object):
                 for _cui in cuis:
                     self.linker.context_model.train(cui=_cui, entity=spacy_entity, doc=spacy_doc, negative=True)  # type: ignore
 
+    @deprecated(message="Use train_supervised_from_json to train based on data "
+                "loaded from a json file")
     def train_supervised(self,
                          data_path: str,
                          reset_cui_count: bool = False,
@@ -937,6 +939,33 @@ class CAT(object):
             examples (dict):
                 FP/FN examples of sentences for each CUI.
         """
+        return self.train_supervised_from_json(data_path, reset_cui_count, nepochs,
+                                               print_stats, use_filters, terminate_last,
+                                               use_overlaps, use_cui_doc_limit, test_size,
+                                               devalue_others, use_groups, never_terminate,
+                                               train_from_false_positives, extra_cui_filter,
+                                               retain_extra_cui_filter, checkpoint,
+                                               retain_filters, is_resumed)
+
+    def train_supervised_from_json(self,
+                                   data_path: str,
+                                   reset_cui_count: bool = False,
+                                   nepochs: int = 1,
+                                   print_stats: int = 0,
+                                   use_filters: bool = False,
+                                   terminate_last: bool = False,
+                                   use_overlaps: bool = False,
+                                   use_cui_doc_limit: bool = False,
+                                   test_size: int = 0,
+                                   devalue_others: bool = False,
+                                   use_groups: bool = False,
+                                   never_terminate: bool = False,
+                                   train_from_false_positives: bool = False,
+                                   extra_cui_filter: Optional[Set] = None,
+                                   retain_extra_cui_filter: bool = False,
+                                   checkpoint: Optional[Checkpoint] = None,
+                                   retain_filters: bool = False,
+                                   is_resumed: bool = False) -> Tuple:
         checkpoint = self._init_ckpts(is_resumed, checkpoint)
 
         local_filters = self.config.linking.filters.copy_of()

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -146,7 +146,7 @@ class MetaCAT(PipeRunner):
                 data_loaded = merge_data_loaded(data_loaded, json.load(f))
         return self.train_raw(data_loaded, save_dir_path)
 
-    def train_raw(self, data_loaded: Dict, save_dir_path: str) -> Dict:
+    def train_raw(self, data_loaded: Dict, save_dir_path: Optional[str] = None) -> Dict:
         """Train or continue training a model given raw data. It will
         continue training if an existing model is loaded or start new training if the model is blank/new.
 

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -15,6 +15,7 @@ from medcat.utils.meta_cat.data_utils import prepare_from_json, encode_category_
 from medcat.pipeline.pipe_runner import PipeRunner
 from medcat.tokenizers.meta_cat_tokenizers import TokenizerWrapperBase
 from medcat.utils.meta_cat.data_utils import Doc as FakeDoc
+from medcat.utils.decorators import deprecated
 
 # It should be safe to do this always, as all other multiprocessing
 # will be finished before data comes to meta_cat
@@ -98,7 +99,21 @@ class MetaCAT(PipeRunner):
         hasher.update(self.config.get_hash())
         return hasher.hexdigest()
 
+    @deprecated(message="Use `train_from_json` or `train_raw` instead")
     def train(self, json_path: Union[str, list], save_dir_path: Optional[str] = None) -> Dict:
+        """Train or continue training a model give a json_path containing a MedCATtrainer export. It will
+        continue training if an existing model is loaded or start new training if the model is blank/new.
+
+        Args:
+            json_path (Union[str, list]):
+                Path/Paths to a MedCATtrainer export containing the meta_annotations we want to train for.
+            save_dir_path (Optional[str]):
+                In case we have aut_save_model (meaning during the training the best model will be saved)
+                we need to set a save path. Defaults to `None`.
+        """
+        return self.train_from_json(json_path, save_dir_path)
+
+    def train_from_json(self, json_path: Union[str, list], save_dir_path: Optional[str] = None) -> Dict:
         """Train or continue training a model give a json_path containing a MedCATtrainer export. It will
         continue training if an existing model is loaded or start new training if the model is blank/new.
 

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -124,8 +124,6 @@ class MetaCAT(PipeRunner):
                 In case we have aut_save_model (meaning during the training the best model will be saved)
                 we need to set a save path. Defaults to `None`.
         """
-        g_config = self.config.general
-        t_config = self.config.train
 
         # Load the medcattrainer export
         if isinstance(json_path, str):
@@ -146,6 +144,39 @@ class MetaCAT(PipeRunner):
         for path in json_path:
             with open(path, 'r') as f:
                 data_loaded = merge_data_loaded(data_loaded, json.load(f))
+        return self.train_raw(data_loaded, save_dir_path)
+
+    def train_raw(self, data_loaded: Dict, save_dir_path: str) -> Dict:
+        """Train or continue training a model given raw data. It will
+        continue training if an existing model is loaded or start new training if the model is blank/new.
+
+        The raw data is expected in the following format:
+        {'projects':
+            [ # list of projects
+                { # project 1
+                    'name': '<some name>',
+                    # list of documents
+                    'documents': [{'name': '<some name>',  # document 1
+                                    'text': '<text of the document>',
+                                    # list of annotations
+                                    'annotations': [{'start': -1,  # annotation 1
+                                                    'end': 1,
+                                                    'cui': 'cui',
+                                                    'value': '<text value>'}, ...],
+                                    }, ...]
+                }, ...
+            ]
+        }
+
+        Args:
+            data_loaded (Dict):
+                The raw data we want to train for.
+            save_dir_path (Optional[str]):
+                In case we have aut_save_model (meaning during the training the best model will be saved)
+                we need to set a save path. Defaults to `None`.
+        """
+        g_config = self.config.general
+        t_config = self.config.train
 
         # Create directories if they don't exist
         if t_config['auto_save_model']:


### PR DESCRIPTION
As outlined in a comment in PR #321 , we are probably better off separating the responsibilities of data loading and training.

As such, this PR attempts to do just that.

It does the following
- Deprecates `CAT.train_supervised` in favour of `CAT.train_supervised_from_json`
- Moves most of the `train_supervised` method logic to `CAT.train_supervised_raw`
- Deprecates `MetaCAT.train` in facour of `MetaCAT.train_from_json`
- Moves most of the `train` method logic to `MetaCAT.train_raw`

This will allow users to generate their own datasets and load it off of wherever they like, instead of being forced to use JSON-formatted files.