### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Since MedCAT is primarily a library, logging has been effectively disabled by de
 The idea is that the user can directly modify the logging behaviour of either the entire library or a certain set of modules within as they wish. We have provided a convenience method to add default handlers that log into the console as well as _medcat.log_ (`medcat.add_default_log_handlers`).
 
 Some details as to how one can configure the logging are described in the [MedCAT Tutorials](https://github.com/CogStack/MedCATtutorials).
-PS: Currently (temporarily!) the tutorial is in the `tutorials` folder.
 
 ## Acknowledgements
 Entity extraction was trained on [MedMentions](https://github.com/chanzuckerberg/MedMentions) In total it has ~ 35K entites from UMLS

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Medical  <img src="https://github.com/CogStack/MedCAT/blob/master/media/cat-logo.png" width=45> oncept Annotation Tool
+# Medical  <img src="https://raw.githubusercontent.com/CogStack/MedCAT/master/media/cat-logo.png" width=45> oncept Annotation Tool
 
 [![Build Status](https://github.com/CogStack/MedCAT/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/CogStack/MedCAT/actions/workflows/main.yml?query=branch%3Amaster)
 [![Documentation Status](https://readthedocs.org/projects/medcat/badge/?version=latest)](https://medcat.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
On [pypi](https://pypi.org/project/medcat/), the C for Medical *C*concept Annotation Tool is not rendered.
Apparently it's because the current image refers to:
https://github.com/CogStack/MedCAT/blob/master/media/cat-logo.png
Which has the frame.
So I swapped it in favour of the raw image:
https://raw.githubusercontent.com/CogStack/MedCAT/master/media/cat-logo.png


Also removes an old comment from README regarding logging tutorials.
