### PR TITLE
CU-8692kn0yv Fix issue with fake dict in identifier based config

### DIFF
--- a/medcat/config.py
+++ b/medcat/config.py
@@ -28,7 +28,11 @@ class FakeDict:
     """FakeDict that allows the use of the __getitem__ and __setitem__ method for legacy access."""
 
     def __getitem__(self, arg: str) -> Any:
-        return getattr(self, arg)
+        try:
+            return getattr(self, arg)
+        except AttributeError as e:
+            raise KeyError from e
+
 
     def __setitem__(self, arg: str, val) -> None:
         setattr(self, arg, val)


### PR DESCRIPTION
More specifically the get method which was not able to return default values for non-existant keys.

This PR will make sure the `__getitem__` method of `FakeDict` will raise a _KeyError_ as would be expected for a _dict_ instead of an _AttributionError_ (which was the case up until now).
This will ensure that the `FakeDict.get` method will catch the correct exception in the `except` clause.

Issue raised here:
https://discourse.cogstack.org/t/attribute-error-for-medcat-trainer/234