### PR TITLE
CU-8692mevx8 Fix issue with filters not taking effect in train_supervised method

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -490,7 +490,8 @@ class CAT(object):
         fp_docs: Set = set()
         fn_docs: Set = set()
 
-        local_filters = self.config.linking.filters.copy_of()
+        orig_filters = self.config.linking.filters.copy_of()
+        local_filters = self.config.linking.filters
         for pind, project in tqdm(enumerate(data['projects']), desc="Stats project", total=len(data['projects']), leave=False):
             local_filters.cuis = set()
 
@@ -644,6 +645,8 @@ class CAT(object):
 
         except Exception:
             traceback.print_exc()
+
+        self.config.linking.filters = orig_filters
 
         return fps, fns, tps, cui_prec, cui_rec, cui_f1, cui_counts, examples
 
@@ -1033,7 +1036,13 @@ class CAT(object):
         """
         checkpoint = self._init_ckpts(is_resumed, checkpoint)
 
-        local_filters = self.config.linking.filters.copy_of()
+        # the config.linking.filters stuff is used directly in
+        # medcat.linking.context_based_linker and medcat.linking.vector_context_model
+        # as such, they need to be kept up to date with per-project filters
+        # However, the original state needs to be kept track of
+        # so that it can be restored after training
+        orig_filters = self.config.linking.filters.copy_of()
+        local_filters = self.config.linking.filters
 
         fp = fn = tp = p = r = f1 = examples = {}
 
@@ -1161,6 +1170,9 @@ class CAT(object):
                                                                                use_overlaps=use_overlaps,
                                                                                use_groups=use_groups,
                                                                                extra_cui_filter=extra_cui_filter)
+
+        # reset the state of filters
+        self.config.linking.filters = orig_filters
 
         return fp, fn, tp, p, r, f1, cui_counts, examples
 

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -1103,7 +1103,7 @@ class CAT(object):
                 if retain_filters and extra_cui_filter and not retain_extra_cui_filter:
                     # adding project filters without extra_cui_filters
                     self._set_project_filters(local_filters, project, set(), use_filters)
-                    self.config.linking.filters.merge_with(local_filters)
+                    orig_filters.merge_with(local_filters)
                     # adding extra_cui_filters, but NOT project filters
                     self._set_project_filters(local_filters, project, extra_cui_filter, False)
                     # refrain from doing it again for subsequent epochs
@@ -1149,7 +1149,7 @@ class CAT(object):
                         checkpoint.save(self.cdb, latest_trained_step)
                 # if retaining MCT filters AND (if they exist) extra_cui_filters
                 if retain_filters:
-                    self.config.linking.filters.merge_with(local_filters)
+                    orig_filters.merge_with(local_filters)
                     # refrain from doing it again for subsequent epochs
                     retain_filters = False
 


### PR DESCRIPTION
This is still a WIP.

But I identified an issue.

So it looks like when I made the change in #274 I had misunderstood the reason for the copying of the linking filters and "solved" it in a way that made the local filters not available for the vector context model or context based linker.

So effectively, the per-project filters and the extra CUI filters weren't taken into account at all.

So this PR will fix that.

With that said, there may be other issues in there. So I'd say this is still a WIP.

PS:
If someone wants to try this, they can install `medcat` based on this branch:
```
pip install https://github.com/mart-r/MedCAT/archive/CU-8692mevx8-supervised_train_filter.zip
```
Or to try and add it to an older version you can cherry-pick the change:
```
# Add my remote
git remote add mrfork git://github.com/mart-r/MedCAT
# Fetch
git fetch mrfork
# Cherry-pick commit
git cherry-pick 61c00f545392fce17d648210b51e8e0797e563a9
```
Or you can apply the [patch](https://github.com/mart-r/MedCAT/compare/3aaef44...66dfcb3)