### PR TITLE
CU-8692kn0yv Fix issue with fake dict in identifier based config

### DIFF
--- a/medcat/config.py
+++ b/medcat/config.py
@@ -28,7 +28,11 @@ class FakeDict:
     """
 
     def __getitem__(self, arg: str) -> Any:
-        return getattr(self, arg)
+        try:
+            return getattr(self, arg)
+        except AttributeError as e:
+            raise KeyError from e
+
 
     def __setitem__(self, arg: str, val) -> None:
         setattr(self, arg, val)


### PR DESCRIPTION
More specifically the get method which was not able to return default values for non-existant keys (#341)