### PR TITLE
Fix issue with GHA targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       github.ref == 'refs/heads/master' &&
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags') != true
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     concurrency: publish-to-test-pypi
     needs: [build]
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-n-publish-to-pypi:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     concurrency: build-n-publish-to-pypi
     if: github.repository == 'CogStack/MedCAT'
 

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -28,7 +28,11 @@ class FakeDict:
     """
 
     def __getitem__(self, arg: str) -> Any:
-        return getattr(self, arg)
+        try:
+            return getattr(self, arg)
+        except AttributeError as e:
+            raise KeyError from e
+
 
     def __setitem__(self, arg: str, val) -> None:
         setattr(self, arg, val)


### PR DESCRIPTION
Move from Ubuntu 18.04 (which doesn't run on anything anymore) to Ubuntu 20.04 so GitHub Actions can run (both main and production).