### PR TITLE
CU-8692uznvd: Allow empty-dict config.linking.filters.cuis and convert to set in memory

### DIFF
--- a/medcat/config.py
+++ b/medcat/config.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from pydantic import BaseModel, Extra, ValidationError
+from pydantic import BaseModel, Extra, ValidationError, validator
 from pydantic.dataclasses import Any, Callable, Dict, Optional, Union
 from pydantic.fields import ModelField
 from typing import List, Set, Tuple, cast
@@ -432,6 +432,19 @@ class LinkingFilters(MixingConfig, BaseModel):
     """
     cuis: Set[str] = set()
     cuis_exclude: Set[str] = set()
+
+    @validator("cuis", pre=True, always=True)
+    def convert_empty_dict_to_set(cls, value):
+        if isinstance(value, dict) and not value:
+            # is empty dict
+            logger.warning("Loading an old model where "
+                           "config.linking.filters.cuis has been "
+                           "dict to an empty dict instead of an empty "
+                           "set. Converting the dict to a set in memory "
+                           "as that is what is expected. Please consider "
+                           "saving the model again.")
+            return set()
+        return value
 
     def check_filters(self, cui: str) -> bool:
         """Checks is a CUI in the filters

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from pydantic import BaseModel, Extra, ValidationError, validator
+from pydantic import BaseModel, Extra, ValidationError
 from pydantic.dataclasses import Any, Callable, Dict, Optional, Union
 from pydantic.fields import ModelField
 from typing import List, Set, Tuple, cast

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -433,18 +433,18 @@ class LinkingFilters(MixingConfig, BaseModel):
     cuis: Set[str] = set()
     cuis_exclude: Set[str] = set()
 
-    @validator("cuis", pre=True, always=True)
-    def convert_empty_dict_to_set(cls, value):
-        if isinstance(value, dict) and not value:
-            # is empty dict
-            logger.warning("Loading an old model where "
-                           "config.linking.filters.cuis has been "
-                           "dict to an empty dict instead of an empty "
-                           "set. Converting the dict to a set in memory "
-                           "as that is what is expected. Please consider "
-                           "saving the model again.")
-            return set()
-        return value
+    def __init__(self, **data):
+        if 'cuis' in data:
+            cuis = data['cuis']
+            if isinstance(cuis, dict) and len(cuis) == 0:
+                logger.warning("Loading an old model where "
+                               "config.linking.filters.cuis has been "
+                               "dict to an empty dict instead of an empty "
+                               "set. Converting the dict to a set in memory "
+                               "as that is what is expected. Please consider "
+                               "saving the model again.")
+                data['cuis'] = set(cuis.keys())
+        super().__init__(**data)
 
     def check_filters(self, cui: str) -> bool:
         """Checks is a CUI in the filters

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import unittest
 import pickle
 import tempfile
-from medcat.config import Config, MixingConfig, VersionInfo, General
+from medcat.config import Config, MixingConfig, VersionInfo, General, LinkingFilters
 from pydantic import ValidationError
 import os
 
@@ -178,6 +178,25 @@ class ConfigTests(unittest.TestCase):
     def test_from_dict(self):
         config = Config.from_dict({"key": "value"})
         self.assertEqual("value", config.key)
+
+
+class ConfigLinkingFiltersTests(unittest.TestCase):
+
+    def test_allows_empty_dict_for_cuis(self):
+        lf = LinkingFilters(cuis={})
+        self.assertIsNotNone(lf)
+
+    def test_empty_dict_converted_to_empty_set(self):
+        lf = LinkingFilters(cuis={})
+        self.assertEqual(lf.cuis, set())
+
+    def test_not_allow_nonempty_dict_for_cuis(self):
+        with self.assertRaises(ValidationError):
+            LinkingFilters(cuis={"KEY": "VALUE"})
+
+    def test_not_allow_empty_dict_for_cuis_exclude(self):
+        with self.assertRaises(ValidationError):
+            LinkingFilters(cuis_exclude={})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is related to #313

While the mentioned PR added an option to convert an existing model, this one makes the change on the fly.

This will allow loading older models with this specific issue without any preconditioning (i.e without the need to manually convert).

The only issue I see is that this automatic change (from empty `dict` to empty `set`) is likely to change the hash of the `Config`, which in turns changes the hash of the `CDB`, which in turn changes the hash of the model pack.
While this may not be an issue in of itself, it could cause some confusion.