### PR TITLE
CU-2cdpd4t: Unify default addl_info in different methods.

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -1332,7 +1332,7 @@ class CAT(object):
                         nproc: int = 2,
                         batch_size_chars: int = 5000 * 1000,
                         only_cui: bool = False,
-                        addl_info: List[str] = [],
+                        addl_info: List[str] = ['cui2icd10', 'cui2ontologies', 'cui2snomed'],
                         separate_nn_components: bool = True,
                         out_split_size_chars: Optional[int] = None,
                         save_dir_path: str = os.path.abspath(os.getcwd()),
@@ -1528,7 +1528,7 @@ class CAT(object):
                              nproc: Optional[int] = None,
                              batch_size: Optional[int] = None,
                              only_cui: bool = False,
-                             addl_info: List[str] = [],
+                             addl_info: List[str] = ['cui2icd10', 'cui2ontologies', 'cui2snomed'],
                              return_dict: bool = True,
                              batch_factor: int = 2) -> Union[List[Tuple], Dict]:
         """Run multiprocessing NOT FOR TRAINING


### PR DESCRIPTION
The defaults for `get_entities` and `get_entities_mulit_texts` was `['cui2icd10', 'cui2ontologies', 'cui2snomed']`.
Whereas the defaults for `multiprocessing` and `multiprocessing_pipe` was `[]`.

Synced the defaults for the latter two with the former two.

Left the default `_multiprocessing_batch` for untouched since this is a protected method which shouldn't be called from outside the library. And it's currently called within `multiprocessing` along with the `addl_info` passed to it.

PS:
This does still change default behaviour for those using the affected methods. But it shouldn't be too troublesome since all the existing data will still be there. It simply potentially adds new things to the output.
