### PR TITLE
Cu 1yn0v9e duplicate multiprocessing methods

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -1546,7 +1546,22 @@ class CAT(object):
 
         return docs
 
-    def multiprocessing_pipe(self,
+    @deprecated(message="Use `multiprocessing_batch_nr_of_docs` instead")
+    def multiprocessing_pipe(self, in_data: Union[List[Tuple], Iterable[Tuple]],
+                             nproc: Optional[int] = None,
+                             batch_size: Optional[int] = None,
+                             only_cui: bool = False,
+                             addl_info: List[str] = [],
+                             return_dict: bool = True,
+                             batch_factor: int = 2) -> Union[List[Tuple], Dict]:
+        return self.multiprocessing_batch_nr_of_docs(in_data=in_data, nproc=nproc,
+                                                     batch_size=batch_size,
+                                                     only_cui=only_cui,
+                                                     addl_info=addl_info,
+                                                     return_dict=return_dict,
+                                                     batch_factor=batch_factor)
+
+    def multiprocessing_batch_nr_of_docs(self,
                              in_data: Union[List[Tuple], Iterable[Tuple]],
                              nproc: Optional[int] = None,
                              batch_size: Optional[int] = None,
@@ -1554,7 +1569,12 @@ class CAT(object):
                              addl_info: List[str] = [],
                              return_dict: bool = True,
                              batch_factor: int = 2) -> Union[List[Tuple], Dict]:
-        """Run multiprocessing NOT FOR TRAINING
+        """Run multiprocessing NOT FOR TRAINING.
+
+        Thios method batches the data based on the number of documents as specified by the user.
+
+        PS:
+        This method supports Windows.
 
         Args:
             in_data (Union[List[Tuple], Iterable[Tuple]]): List with format: [(id, text), (id, text), ...]

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -1327,6 +1327,7 @@ class CAT(object):
             pickle.dump((annotated_ids, part_counter), open(annotated_ids_path, 'wb'))
         return part_counter
 
+    @deprecated(message="Use `multiprocessing_batch_char_size` instead")
     def multiprocessing(self,
                         data: Union[List[Tuple], Iterable[Tuple]],
                         nproc: int = 2,
@@ -1337,8 +1338,30 @@ class CAT(object):
                         out_split_size_chars: Optional[int] = None,
                         save_dir_path: str = os.path.abspath(os.getcwd()),
                         min_free_memory=0.1) -> Dict:
+        return self.multiprocessing_batch_char_size(data=data, nproc=nproc,
+                                                    batch_size_chars=batch_size_chars,
+                                                    only_cui=only_cui, addl_info=addl_info,
+                                                    separate_nn_components=separate_nn_components,
+                                                    out_split_size_chars=out_split_size_chars,
+                                                    save_dir_path=save_dir_path,
+                                                    min_free_memory=min_free_memory)
+
+    def multiprocessing_batch_char_size(self,
+                                        data: Union[List[Tuple], Iterable[Tuple]],
+                                        nproc: int = 2,
+                                        batch_size_chars: int = 5000 * 1000,
+                                        only_cui: bool = False,
+                                        addl_info: List[str] = [],
+                                        separate_nn_components: bool = True,
+                                        out_split_size_chars: Optional[int] = None,
+                                        save_dir_path: str = os.path.abspath(os.getcwd()),
+                                        min_free_memory=0.1) -> Dict:
         r"""Run multiprocessing for inference, if out_save_path and out_split_size_chars is used this will also continue annotating
         documents if something is saved in that directory.
+
+        This method batches the data based on the number of characters as specified by user.
+
+        PS: This method is unlikely to work on a Windows machine.
 
         Args:
             data:

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -1546,7 +1546,7 @@ class CAT(object):
 
         return docs
 
-    @deprecated(message="Use `multiprocessing_batch_nr_of_docs` instead")
+    @deprecated(message="Use `multiprocessing_batch_docs_size` instead")
     def multiprocessing_pipe(self, in_data: Union[List[Tuple], Iterable[Tuple]],
                              nproc: Optional[int] = None,
                              batch_size: Optional[int] = None,
@@ -1554,14 +1554,14 @@ class CAT(object):
                              addl_info: List[str] = [],
                              return_dict: bool = True,
                              batch_factor: int = 2) -> Union[List[Tuple], Dict]:
-        return self.multiprocessing_batch_nr_of_docs(in_data=in_data, nproc=nproc,
+        return self.multiprocessing_batch_docs_size(in_data=in_data, nproc=nproc,
                                                      batch_size=batch_size,
                                                      only_cui=only_cui,
                                                      addl_info=addl_info,
                                                      return_dict=return_dict,
                                                      batch_factor=batch_factor)
 
-    def multiprocessing_batch_nr_of_docs(self,
+    def multiprocessing_batch_docs_size(self,
                              in_data: Union[List[Tuple], Iterable[Tuple]],
                              nproc: Optional[int] = None,
                              batch_size: Optional[int] = None,
@@ -1571,7 +1571,7 @@ class CAT(object):
                              batch_factor: int = 2) -> Union[List[Tuple], Dict]:
         """Run multiprocessing NOT FOR TRAINING.
 
-        Thios method batches the data based on the number of documents as specified by the user.
+        This method batches the data based on the number of documents as specified by the user.
 
         PS:
         This method supports Windows.

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -60,7 +60,7 @@ class CATTests(unittest.TestCase):
             (2, ""),
             (3, None)
         ]
-        out = self.undertest.multiprocessing(in_data, nproc=1)
+        out = self.undertest.multiprocessing_batch_char_size(in_data, nproc=1)
 
         self.assertEqual(3, len(out))
         self.assertEqual(1, len(out[1]['entities']))

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -73,7 +73,7 @@ class CATTests(unittest.TestCase):
             (2, "The dog is sitting outside the house."),
             (3, "The dog is sitting outside the house."),
         ]
-        out = self.undertest.multiprocessing_batch_nr_of_docs(in_data, nproc=2, return_dict=False)
+        out = self.undertest.multiprocessing_batch_docs_size(in_data, nproc=2, return_dict=False)
         self.assertTrue(type(out) == list)
         self.assertEqual(3, len(out))
         self.assertEqual(1, out[0][0])
@@ -89,7 +89,7 @@ class CATTests(unittest.TestCase):
             (2, ""),
             (3, None),
         ]
-        out = self.undertest.multiprocessing_batch_nr_of_docs(in_data, nproc=1, batch_size=1, return_dict=False)
+        out = self.undertest.multiprocessing_batch_docs_size(in_data, nproc=1, batch_size=1, return_dict=False)
         self.assertTrue(type(out) == list)
         self.assertEqual(3, len(out))
         self.assertEqual(1, out[0][0])
@@ -105,7 +105,7 @@ class CATTests(unittest.TestCase):
             (2, "The dog is sitting outside the house."),
             (3, "The dog is sitting outside the house.")
         ]
-        out = self.undertest.multiprocessing_batch_nr_of_docs(in_data, nproc=2, return_dict=True)
+        out = self.undertest.multiprocessing_batch_docs_size(in_data, nproc=2, return_dict=True)
         self.assertTrue(type(out) == dict)
         self.assertEqual(3, len(out))
         self.assertEqual({'entities': {}, 'tokens': []}, out[1])

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -73,7 +73,7 @@ class CATTests(unittest.TestCase):
             (2, "The dog is sitting outside the house."),
             (3, "The dog is sitting outside the house."),
         ]
-        out = self.undertest.multiprocessing_pipe(in_data, nproc=2, return_dict=False)
+        out = self.undertest.multiprocessing_batch_nr_of_docs(in_data, nproc=2, return_dict=False)
         self.assertTrue(type(out) == list)
         self.assertEqual(3, len(out))
         self.assertEqual(1, out[0][0])
@@ -89,7 +89,7 @@ class CATTests(unittest.TestCase):
             (2, ""),
             (3, None),
         ]
-        out = self.undertest.multiprocessing_pipe(in_data, nproc=1, batch_size=1, return_dict=False)
+        out = self.undertest.multiprocessing_batch_nr_of_docs(in_data, nproc=1, batch_size=1, return_dict=False)
         self.assertTrue(type(out) == list)
         self.assertEqual(3, len(out))
         self.assertEqual(1, out[0][0])
@@ -105,7 +105,7 @@ class CATTests(unittest.TestCase):
             (2, "The dog is sitting outside the house."),
             (3, "The dog is sitting outside the house.")
         ]
-        out = self.undertest.multiprocessing_pipe(in_data, nproc=2, return_dict=True)
+        out = self.undertest.multiprocessing_batch_nr_of_docs(in_data, nproc=2, return_dict=True)
         self.assertTrue(type(out) == dict)
         self.assertEqual(3, len(out))
         self.assertEqual({'entities': {}, 'tokens': []}, out[1])


### PR DESCRIPTION
There are multiple methods for multiprocessing.
But it is not always clear why one should prefer one to another.
This PR attempts to fix that by deprecating the old methods and renaming them with a new, more descriptive name. It also adds some documentation regarding their differences to the docstrings.

From my research, here's what the differences of the existing methods are:
What I managed to dig up from code and tutorials:
- `multiprocessing`
   - Batching based on the character size
   - Does not support Windows (at least implied in tutorial Part 3.2)
- `multiprocessing_pipe`
   - Batching based on number of documents
   - Does support Windows
- `get_entities_multi_texts`
   - Used within `multiprocessing_pipe`
     - So should be Windows-safe
   - Otherwise, more of a convenience method get get_entities 
