### PR TITLE
8693az82g Remove cdb tests side effects

### DIFF
--- a/medcat/cdb_maker.py
+++ b/medcat/cdb_maker.py
@@ -49,6 +49,14 @@ class CDBMaker(object):
                              name='skip_and_punct',
                              additional_fields=['is_punct'])
 
+    def reset_cdb(self) -> None:
+        """This will re-create a new internal CDB based on the same config.
+
+        This will be necessary if/when you're wishing to call `prepare_csvs`
+        multiple times on the same object `CDBMaker` instance.
+        """
+        self.cdb = CDB(config=self.config)
+
     def prepare_csvs(self,
                      csv_paths: Union[pd.DataFrame, List[str]],
                      sep: str = ',',
@@ -58,6 +66,12 @@ class CDBMaker(object):
                      full_build: bool = False,
                      only_existing_cuis: bool = False, **kwargs) -> CDB:
         r"""Compile one or multiple CSVs into a CDB.
+
+        Note: This class/method generally uses the same instance of the CDB.
+              So if you're using the same CDBMaker and calling `prepare_csvs`
+              multiple times, you are likely to get leakage from prior calls
+              into new ones.
+              To reset the CDB, call `reset_cdb`.
 
         Args:
             csv_paths (Union[pd.DataFrame, List[str]]):

--- a/tests/test_cdb.py
+++ b/tests/test_cdb.py
@@ -27,6 +27,12 @@ class CDBTests(unittest.TestCase):
     def tearDown(self) -> None:
         shutil.rmtree(self.tmp_dir)
 
+    def test_setup_changes_cdb(self):
+        id1 = id(self.undertest)
+        self.setUp()
+        id2 = id(self.undertest)
+        self.assertNotEqual(id1, id2)
+
     def test_name2cuis(self):
         self.assertEqual({
             'second~csv': ['C0000239'],

--- a/tests/test_cdb.py
+++ b/tests/test_cdb.py
@@ -22,6 +22,10 @@ class CDBTests(unittest.TestCase):
         cdb_2_csv = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "examples", "cdb_2.csv")
         self.tmp_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp")
         os.makedirs(self.tmp_dir, exist_ok=True)
+        # resetting the CDB because otherwise the CDBMaker
+        # will refer to and modify the same instance of the CDB
+        # and this can (and does!) create side effects
+        CDBTests.cdb_maker.reset_cdb()
         self.undertest = CDBTests.cdb_maker.prepare_csvs([cdb_csv, cdb_2_csv], full_build=True)
 
     def tearDown(self) -> None:


### PR DESCRIPTION
The `CDBMaker.prepare_csvs` method always refers to the same CDB instance

As used in tests/test_cdb.py.
Because of the way the test is set up (`CDBMaker` initialised in class setup and prepare_csvs  called in per-test setup), this is likely to cause side effects (changes from previous tests persisting through to next ones).

As an example, the `test_remove_cui` will remove the CUI `C0000039` , however, other tests running after that (the order in which tests run is independent of the order in which they're written) will also have that CUI removed from the CDB.


This PR:
- [x] Adds a new method to `CDBMaker` to reset its CDB along with docstring as to when/why
- [x] Adds a test to make sure the `setUp` method creates a new CDB
- [x] Makes sure to reset the `CDB` within `CDBMaker` before each test in `cdb_tests.py`

What I suppose we could add would be a logged warning upon second execution of `CDMaker.prepare_csvs`. Though since I didn't think that was actually too common a workflow, I did not do it as of yet.