### PR TITLE
CU-8693b0a61 Add method to get spacy model version

### DIFF
--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -11,6 +11,7 @@ import spacy
 
 SPACY_MODEL_REGEX = re.compile(r"(\w{2}_core_(\w{3,4})_(sm|md|lg|trf|xxl|\w+))|(spacy_model)")
 
+
 def is_spacy_model_folder(folder_name: str) -> bool:
     """Check if a folder within a model pack contains a spacy model.
 
@@ -81,7 +82,7 @@ def get_installed_model_version(model_name: str) -> str:
     return spacy.info(model_name)['version']
 
 
-def get_name_and_meta_of_spacy_model(model_pack_path: str) -> Tuple[str, dict]:
+def get_name_and_meta_of_spacy_model_in_medcat_modelpack(model_pack_path: str) -> Tuple[str, dict]:
     """Gets the name and meta information about a spacy model within a medcat model pack.
 
     Args:

--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -87,6 +87,11 @@ def get_installed_model_version(model_name: str) -> str:
 def get_name_and_meta_of_spacy_model_in_medcat_modelpack(model_pack_path: str) -> Tuple[str, dict]:
     """Gets the name and meta information about a spacy model within a medcat model pack.
 
+    PS: This gets the raw (folder) name of the spacy model.
+        While this is usually (in models created after v1.2.4)
+        identical to the spacy model version, that may not always
+        be the case.
+
     Args:
         model_pack_path (str): The model pack path.
 
@@ -103,11 +108,17 @@ def get_name_and_meta_of_spacy_model_in_medcat_modelpack(model_pack_path: str) -
 def get_name_and_version_of_spacy_model_in_medcat_modelpack(model_pack_path: str) -> Tuple[str, str]:
     """Get the name and version of a spacy model within a medcat model pack.
 
+    PS: This gets the real name of the spacy model.
+        While this is usually (in models created after v1.2.4)
+        identical to the folder name, that may not always
+        be the case.
+
     Args:
         model_pack_path (str): The model pack path.
 
     Returns:
         Tuple[str, str]: The name of the spacy model, and the version.
     """
-    name, info = get_name_and_meta_of_spacy_model_in_medcat_modelpack(model_pack_path)
-    return name, info['version']
+    _, info = get_name_and_meta_of_spacy_model_in_medcat_modelpack(model_pack_path)
+    true_name = info["lang"] + "_" + info['name']
+    return true_name, info['version']

--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -1,0 +1,33 @@
+"""This module attempts to read the spacy compatibilty of
+a model pack and (if necessary) compare it to the installed
+spacy version.
+"""
+from typing import Tuple, List
+import os
+import re
+
+import spacy
+
+
+SPACY_MODEL_REGEX = re.compile(r"(\w{2}_core_(\w{3,4})_(sm|md|lg|trf|xxl|\w+))|(spacy_model)")
+
+def is_spacy_model_folder(folder_name: str) -> bool:
+    """Check if a folder within a model pack contains a spacy model.
+
+    The idea is to do this without loading the model. That is because
+    the version of the model may be incompatible with what we've got.
+    And as such, loading may not be possible.
+
+    Args:
+        folder_name (str): The folder to check.
+
+    Returns:
+        bool: Whether the folder contains a spacy model.
+    """
+    # since we're trying to identify this solely from the
+    # folder name, we only care about the base name.
+    folder_name = os.path.basename(folder_name)
+    if folder_name.startswith("meta_"):
+        # these are MetaCat stuff (or should be)
+        return False
+    return bool(SPACY_MODEL_REGEX.match(folder_name))

--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -32,6 +32,7 @@ def is_spacy_model_folder(folder_name: str) -> bool:
         return False
     return bool(SPACY_MODEL_REGEX.match(folder_name))
 
+
 def find_spacy_model_folder(model_pack_folder: str) -> str:
     """Find the spacy model folder in a model pack folder.
 
@@ -56,5 +57,17 @@ def find_spacy_model_folder(model_pack_folder: str) -> str:
                          f"{len(options)} ambiguous folders: {options}")
     return os.path.join(model_pack_folder, options[0])
 
+
 def get_installed_spacy_version() -> str:
+    """Get the spacy version installed currently.
+
+    Returns:
+        str: The currently installed spacy verison.
+    """
     return spacy.__version__
+
+
+def get_installed_model_version(model_name: str) -> str:
+    if model_name not in spacy.util.get_installed_models():
+        return 'N/A'
+    return spacy.info(model_name)['version']

--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -101,5 +101,13 @@ def get_name_and_meta_of_spacy_model_in_medcat_modelpack(model_pack_path: str) -
 
 
 def get_name_and_version_of_spacy_model_in_medcat_modelpack(model_pack_path: str) -> Tuple[str, str]:
+    """Get the name and version of a spacy model within a medcat model pack.
+
+    Args:
+        model_pack_path (str): The model pack path.
+
+    Returns:
+        Tuple[str, str]: The name of the spacy model, and the version.
+    """
     name, info = get_name_and_meta_of_spacy_model_in_medcat_modelpack(model_pack_path)
     return name, info['version']

--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -68,12 +68,28 @@ def get_installed_spacy_version() -> str:
 
 
 def get_installed_model_version(model_name: str) -> str:
+    """Get the version of a model installed in spacy.
+
+    Args:
+        model_name (str): The model name.
+
+    Returns:
+        str: The version of the installed model.
+    """
     if model_name not in spacy.util.get_installed_models():
         return 'N/A'
     return spacy.info(model_name)['version']
 
 
 def get_name_and_meta_of_spacy_model(model_pack_path: str) -> Tuple[str, dict]:
+    """Gets the name and meta information about a spacy model within a medcat model pack.
+
+    Args:
+        model_pack_path (str): The model pack path.
+
+    Returns:
+        Tuple[str, dict]: The name of the spacy model, and the meta information.
+    """
     spacy_model_folder = find_spacy_model_folder(model_pack_path)
     info = spacy.info(spacy_model_folder)
     return os.path.basename(spacy_model_folder), info

--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -94,3 +94,8 @@ def get_name_and_meta_of_spacy_model_in_medcat_modelpack(model_pack_path: str) -
     spacy_model_folder = find_spacy_model_folder(model_pack_path)
     info = spacy.info(spacy_model_folder)
     return os.path.basename(spacy_model_folder), info
+
+
+def get_name_and_version_of_spacy_model_in_medcat_modelpack(model_pack_path: str) -> Tuple[str, str]:
+    name, info = get_name_and_meta_of_spacy_model_in_medcat_modelpack(model_pack_path)
+    return name, info['version']

--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -2,7 +2,7 @@
 a model pack and (if necessary) compare it to the installed
 spacy version.
 """
-from typing import Tuple, List
+from typing import Tuple, List, cast
 import os
 import re
 
@@ -79,7 +79,9 @@ def get_installed_model_version(model_name: str) -> str:
     """
     if model_name not in spacy.util.get_installed_models():
         return 'N/A'
-    return spacy.info(model_name)['version']
+    # NOTE: I don't really know when spacy.info
+    # might return a str instead
+    return cast(dict, spacy.info(model_name))['version']
 
 
 def get_name_and_meta_of_spacy_model_in_medcat_modelpack(model_pack_path: str) -> Tuple[str, dict]:
@@ -92,7 +94,9 @@ def get_name_and_meta_of_spacy_model_in_medcat_modelpack(model_pack_path: str) -
         Tuple[str, dict]: The name of the spacy model, and the meta information.
     """
     spacy_model_folder = find_spacy_model_folder(model_pack_path)
-    info = spacy.info(spacy_model_folder)
+    # NOTE: I don't really know when spacy.info
+    # might return a str instead
+    info = cast(dict, spacy.info(spacy_model_folder))
     return os.path.basename(spacy_model_folder), info
 
 

--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -55,7 +55,7 @@ def find_spacy_model_folder(model_pack_folder: str) -> str:
     if len(options) != 1:
         raise ValueError("Unable to determine spacy folder name from "
                          f"{len(options)} ambiguous folders: {options}")
-    return os.path.join(model_pack_folder, options[0])
+    return options[0]
 
 
 def get_installed_spacy_version() -> str:

--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -31,3 +31,27 @@ def is_spacy_model_folder(folder_name: str) -> bool:
         # these are MetaCat stuff (or should be)
         return False
     return bool(SPACY_MODEL_REGEX.match(folder_name))
+
+def find_spacy_model_folder(model_pack_folder: str) -> str:
+    """Find the spacy model folder in a model pack folder.
+
+    Args:
+        model_pack_folder (str): The model pack folder
+
+    Raises:
+        ValueError: If it's ambiguous or there's no model folder.
+
+    Returns:
+        str: The full path to the model folder.
+    """
+    options: List[str] = []
+    for folder_name in os.listdir(model_pack_folder):
+        full_folder_path = os.path.join(model_pack_folder, folder_name)
+        if not os.path.isdir(full_folder_path):
+            continue
+        if is_spacy_model_folder(folder_name):
+            options.append(full_folder_path)
+    if len(options) != 1:
+        raise ValueError("Unable to determine spacy folder name from "
+                         f"{len(options)} ambiguous folders: {options}")
+    return os.path.join(model_pack_folder, options[0])

--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -71,3 +71,9 @@ def get_installed_model_version(model_name: str) -> str:
     if model_name not in spacy.util.get_installed_models():
         return 'N/A'
     return spacy.info(model_name)['version']
+
+
+def get_name_and_meta_of_spacy_model(model_pack_path: str) -> Tuple[str, dict]:
+    spacy_model_folder = find_spacy_model_folder(model_pack_path)
+    info = spacy.info(spacy_model_folder)
+    return os.path.basename(spacy_model_folder), info

--- a/medcat/utils/spacy_compatibility.py
+++ b/medcat/utils/spacy_compatibility.py
@@ -55,3 +55,6 @@ def find_spacy_model_folder(model_pack_folder: str) -> str:
         raise ValueError("Unable to determine spacy folder name from "
                          f"{len(options)} ambiguous folders: {options}")
     return os.path.join(model_pack_folder, options[0])
+
+def get_installed_spacy_version() -> str:
+    return spacy.__version__

--- a/tests/resources/ff_core_fake_dr/meta.json
+++ b/tests/resources/ff_core_fake_dr/meta.json
@@ -1,6 +1,6 @@
 {
     "lang":"ff",
-    "name":"back_offl_dr",
+    "name":"core_fake_dr",
     "version":"3.not.yeah",
     "description":"This is a FAKE model",
     "author":"Fakio Martimus",

--- a/tests/resources/ff_core_fake_dr/meta.json
+++ b/tests/resources/ff_core_fake_dr/meta.json
@@ -1,0 +1,8 @@
+{
+    "lang":"ff",
+    "name":"back_offl_dr",
+    "version":"3.not.yeah",
+    "description":"This is a FAKE model",
+    "author":"Fakio Martimus",
+    "spacy_version":">=3.1.0,<3.2.0"
+  }

--- a/tests/utils/test_spacy_compatibility.py
+++ b/tests/utils/test_spacy_compatibility.py
@@ -1,4 +1,5 @@
 from medcat.utils.spacy_compatibility import is_spacy_model_folder, find_spacy_model_folder
+from medcat.utils.spacy_compatibility import get_installed_spacy_version
 
 import unittest
 
@@ -94,3 +95,12 @@ class FindSpacyFolderMoreFoldersEmptyFilesTests(FindSpacyFolderJustOneFolderEmpt
         folder_names = [os.path.join(cls.fake_modelpack_folder_name, fn) for fn in folder_names]
         for folder in folder_names:
             os.makedirs(folder)
+
+
+class SpacyVersionTests(unittest.TestCase):
+
+    def test_version_received(self):
+        installed = get_installed_spacy_version()
+        import spacy
+        expected = spacy.__version__
+        self.assertEqual(installed, expected)

--- a/tests/utils/test_spacy_compatibility.py
+++ b/tests/utils/test_spacy_compatibility.py
@@ -1,9 +1,11 @@
-from medcat.utils.spacy_compatibility import is_spacy_model_folder
+from medcat.utils.spacy_compatibility import is_spacy_model_folder, find_spacy_model_folder
 
 import unittest
 
 import random
 import string
+import tempfile
+import os
 
 
 class SpacyModelFolderIdentifierTests(unittest.TestCase):
@@ -31,6 +33,12 @@ class SpacyModelFolderIdentifierTests(unittest.TestCase):
     def test_works_legacy_models(self):
         for model_name in self.expected_working_legacy_names:
             with self.subTest(model_name):
+                self.assertTrue(is_spacy_model_folder(model_name))
+
+    def test_works_fill_path(self):
+        for model_name in self.expected_working_legacy_names:
+            full_folder_path = os.path.join("some", "folder", "structure", model_name)
+            with self.subTest(full_folder_path):
                 self.assertTrue(is_spacy_model_folder(model_name))
 
     def get_all_garbage(self) -> list:

--- a/tests/utils/test_spacy_compatibility.py
+++ b/tests/utils/test_spacy_compatibility.py
@@ -1,0 +1,50 @@
+from medcat.utils.spacy_compatibility import is_spacy_model_folder
+
+import unittest
+
+import random
+import string
+
+
+class SpacyModelFolderIdentifierTests(unittest.TestCase):
+    expected_working_spacy_models = [
+        "en_core_sci_sm",
+        "en_core_web_sm",
+        "en_core_web_md",
+        "en_core_web_lg",
+        "en_core_web_trf",
+        "nl_core_news_sm",
+        "nl_core_news_md",
+        "nl_core_news_lg",
+    ]
+    # the following were used in medcat models created prior
+    # to v1.2.4
+    expected_working_legacy_names = [
+        "spacy_model"
+    ]
+
+    def test_works_expected_models(self):
+        for model_name in self.expected_working_spacy_models:
+            with self.subTest(model_name):
+                self.assertTrue(is_spacy_model_folder(model_name))
+
+    def test_works_legacy_models(self):
+        for model_name in self.expected_working_legacy_names:
+            with self.subTest(model_name):
+                self.assertTrue(is_spacy_model_folder(model_name))
+
+    def get_all_garbage(self) -> list:
+        """Generate garbage "spacy names".
+
+        Returns:
+            List[str]: Some random strings that shouldn't be spacy models.
+        """
+        my_examples = ["garbage_in_and_out", "meta_Presence", "something"]
+        true_randoms_N10 = [''.join(random.choices(string.ascii_uppercase + string.digits, k=10)) for _ in range(10)]
+        true_randoms_N20 = [''.join(random.choices(string.ascii_uppercase + string.digits, k=20)) for _ in range(10)]
+        return my_examples + true_randoms_N10 + true_randoms_N20
+
+    def test_does_not_work_grabage(self):
+        for garbage in self.get_all_garbage():
+            with self.subTest(garbage):
+                self.assertFalse(is_spacy_model_folder(garbage))

--- a/tests/utils/test_spacy_compatibility.py
+++ b/tests/utils/test_spacy_compatibility.py
@@ -1,5 +1,6 @@
 from medcat.utils.spacy_compatibility import is_spacy_model_folder, find_spacy_model_folder
 from medcat.utils.spacy_compatibility import get_installed_spacy_version, get_installed_model_version
+from medcat.utils.spacy_compatibility import get_name_and_meta_of_spacy_model
 
 import unittest
 
@@ -117,3 +118,16 @@ class InstalledVersionChecker(unittest.TestCase):
         version = get_installed_model_version(model_name)
         self.assertIsInstance(version, str)
         self.assertEqual(version, "N/A")
+
+
+class GetSpacyModelVersionTests(unittest.TestCase):
+    fake_spacy_model_name = "ff_core_fake_dr"
+    fake_spacy_model_dir = os.path.join("tests", "resources", fake_spacy_model_name)
+    fake_modelpack_model_dir = os.path.join(fake_spacy_model_dir, '..')
+    expected_version = "3.not.yeah"
+
+    def test_can_read_version(self):
+        name, info = get_name_and_meta_of_spacy_model(self.fake_modelpack_model_dir)
+        version = info['version']
+        self.assertEqual(name, self.fake_spacy_model_name)
+        self.assertEqual(version, self.expected_version)

--- a/tests/utils/test_spacy_compatibility.py
+++ b/tests/utils/test_spacy_compatibility.py
@@ -1,6 +1,6 @@
 from medcat.utils.spacy_compatibility import is_spacy_model_folder, find_spacy_model_folder
 from medcat.utils.spacy_compatibility import get_installed_spacy_version, get_installed_model_version
-from medcat.utils.spacy_compatibility import get_name_and_meta_of_spacy_model
+from medcat.utils.spacy_compatibility import get_name_and_meta_of_spacy_model_in_medcat_modelpack
 
 import unittest
 
@@ -127,7 +127,7 @@ class GetSpacyModelVersionTests(unittest.TestCase):
     expected_version = "3.not.yeah"
 
     def test_can_read_version(self):
-        name, info = get_name_and_meta_of_spacy_model(self.fake_modelpack_model_dir)
+        name, info = get_name_and_meta_of_spacy_model_in_medcat_modelpack(self.fake_modelpack_model_dir)
         version = info['version']
         self.assertEqual(name, self.fake_spacy_model_name)
         self.assertEqual(version, self.expected_version)

--- a/tests/utils/test_spacy_compatibility.py
+++ b/tests/utils/test_spacy_compatibility.py
@@ -1,6 +1,7 @@
 from medcat.utils.spacy_compatibility import is_spacy_model_folder, find_spacy_model_folder
 from medcat.utils.spacy_compatibility import get_installed_spacy_version, get_installed_model_version
 from medcat.utils.spacy_compatibility import get_name_and_meta_of_spacy_model_in_medcat_modelpack
+from medcat.utils.spacy_compatibility import get_name_and_version_of_spacy_model_in_medcat_modelpack
 
 import unittest
 
@@ -120,14 +121,28 @@ class InstalledVersionChecker(unittest.TestCase):
         self.assertEqual(version, "N/A")
 
 
-class GetSpacyModelVersionTests(unittest.TestCase):
+class GetSpacyModelInfoTests(unittest.TestCase):
     fake_spacy_model_name = "ff_core_fake_dr"
     fake_spacy_model_dir = os.path.join("tests", "resources", fake_spacy_model_name)
     fake_modelpack_model_dir = os.path.join(fake_spacy_model_dir, '..')
     expected_version = "3.not.yeah"
 
-    def test_can_read_version(self):
-        name, info = get_name_and_meta_of_spacy_model_in_medcat_modelpack(self.fake_modelpack_model_dir)
-        version = info['version']
-        self.assertEqual(name, self.fake_spacy_model_name)
-        self.assertEqual(version, self.expected_version)
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.name, cls.info = get_name_and_meta_of_spacy_model_in_medcat_modelpack(cls.fake_modelpack_model_dir)
+
+    def test_reads_name(self):
+        self.assertEqual(self.name, self.fake_spacy_model_name)
+
+    def test_reads_info(self):
+        self.assertIsInstance(self.info, dict)
+        self.assertTrue(self.info)  # not empty
+
+
+class GetSpacyModelVersionTests(GetSpacyModelInfoTests):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.name, cls.version = get_name_and_version_of_spacy_model_in_medcat_modelpack(cls.fake_modelpack_model_dir)
+
+    def test_version_correct(self):
+        self.assertEqual(self.version, self.expected_version)

--- a/tests/utils/test_spacy_compatibility.py
+++ b/tests/utils/test_spacy_compatibility.py
@@ -1,5 +1,5 @@
 from medcat.utils.spacy_compatibility import is_spacy_model_folder, find_spacy_model_folder
-from medcat.utils.spacy_compatibility import get_installed_spacy_version
+from medcat.utils.spacy_compatibility import get_installed_spacy_version, get_installed_model_version
 
 import unittest
 
@@ -104,3 +104,16 @@ class SpacyVersionTests(unittest.TestCase):
         import spacy
         expected = spacy.__version__
         self.assertEqual(installed, expected)
+
+
+class InstalledVersionChecker(unittest.TestCase):
+
+    def test_existing(self, model_name: str = 'en_core_web_md'):
+        version = get_installed_model_version(model_name)
+        self.assertIsInstance(version, str)
+        self.assertNotEqual(version, "N/A")
+
+    def test_non_existing(self, model_name: str = 'en_core_web_lg'):
+        version = get_installed_model_version(model_name)
+        self.assertIsInstance(version, str)
+        self.assertEqual(version, "N/A")

--- a/tests/utils/test_spacy_compatibility.py
+++ b/tests/utils/test_spacy_compatibility.py
@@ -56,3 +56,41 @@ class SpacyModelFolderIdentifierTests(unittest.TestCase):
         for garbage in self.get_all_garbage():
             with self.subTest(garbage):
                 self.assertFalse(is_spacy_model_folder(garbage))
+
+
+class FindSpacyFolderJustOneFolderEmptyFilesTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls, spacy_folder_name='en_core_web_md') -> None:
+        # setup temp folder
+        cls.temp_folder = tempfile.TemporaryDirectory()
+        cls.fake_modelpack_folder_name = cls.temp_folder.name
+        # create spacy folder
+        cls.spacy_folder = os.path.join(cls.fake_modelpack_folder_name, spacy_folder_name)
+        os.makedirs(cls.spacy_folder)
+        # create 2 empty files
+        filenames = ["file1.dat", "file2.json"]
+        filenames = [os.path.join(cls.fake_modelpack_folder_name, fn) for fn in filenames]
+        for fn in filenames:
+            with open(fn, 'w'):
+                pass # open and write empty file
+    
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temp_folder.cleanup()
+
+    def test_finds(self):
+        found_folder_path = find_spacy_model_folder(self.fake_modelpack_folder_name)
+        self.assertEqual(found_folder_path, self.spacy_folder)
+
+
+class FindSpacyFolderMoreFoldersEmptyFilesTests(FindSpacyFolderJustOneFolderEmptyFilesTests):
+
+    @classmethod
+    def setUpClass(cls, spacy_folder_name='en_core_web_md') -> None:
+        super().setUpClass(spacy_folder_name)
+        # add a few folders
+        folder_names = ["meta_Presence", "garbage_in_garbage_out"]
+        folder_names = [os.path.join(cls.fake_modelpack_folder_name, fn) for fn in folder_names]
+        for folder in folder_names:
+            os.makedirs(folder)


### PR DESCRIPTION
Most compatibility issues seem to boil down to the spacy  version used by medcat being incompatible with the spacy model bundled with a model pack.
We should be able to move forward by knowing which spacy model we're trying to load.

The spacy model is generally saved at `<model_pack>/<spacy_model_name>`  (though at `<model_pack>/spacy_model` for pre 1.2.4 built models).

The `meta.json` file is what spact needs to read the metadata (call `spacy.info` on the folder).

This PR adds a bunch of methods and their corresponding tests. The most notable of these is the following:
`medcat.utils.spacy_compatibility.get_name_and_version_of_spacy_model_in_medcat_modelpack`
It allows us to get the spacy model name and version that's saved within a modelpack.