### PR TITLE
CU-8693bpq82 fallback spacy model

### DIFF
--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -526,7 +526,7 @@ class CDB(object):
         if not os.path.exists(config_path):
             if not self._config_from_file:
                 # if there's no config defined anywhere
-                raise ValueError("Could not find a config in the CDB nor ",
+                raise ValueError("Could not find a config in the CDB nor "
                                  "in the config.json for this model "
                                  f"({os.path.dirname(config_path)})",
                                  )

--- a/medcat/pipe.py
+++ b/medcat/pipe.py
@@ -51,7 +51,7 @@ class Pipe(object):
                            "For best compatibility, we'd recommend "
                            "packaging and using your model pack with "
                            "the spacy model it was designed for",
-                           config.general.spacy_model)
+                           config.general.spacy_model, exc_info=e)
             # we're changing the config value so that this propages
             # to other places that try to load the model. E.g:
             # medcat.utils.normalizers.TokenNormalizer.__init__

--- a/medcat/pipe.py
+++ b/medcat/pipe.py
@@ -22,6 +22,9 @@ from medcat.ner.transformers_ner import TransformersNER
 logger = logging.getLogger(__name__) # different logger from the package-level one
 
 
+DEFAULT_SPACY_MODEL = 'en_core_web_md'
+
+
 class Pipe(object):
     """A wrapper around the standard spacy pipeline.
 
@@ -38,7 +41,23 @@ class Pipe(object):
     """
 
     def __init__(self, tokenizer: Tokenizer, config: Config) -> None:
-        self._nlp = spacy.load(config.general.spacy_model, disable=config.general.spacy_disabled_components)
+        try:
+            self._nlp = self._init_nlp(config)
+        except Exception as e:
+            if config.general.spacy_model == DEFAULT_SPACY_MODEL:
+                raise e
+            logger.warning("Could not load spacy model from '%s'. "
+                           "Falling back to installed en_core_web_md. "
+                           "For best compatibility, we'd recommend "
+                           "packaging and using your model pack with "
+                           "the spacy model it was designed for",
+                           config.general.spacy_model)
+            # we're changing the config value so that this propages
+            # to other places that try to load the model. E.g:
+            # medcat.utils.normalizers.TokenNormalizer.__init__
+            config.general.spacy_model = DEFAULT_SPACY_MODEL
+            self._nlp = self._init_nlp(config)
+            print("TYPE", type(self._nlp))
         if config.preprocessing.stopwords is not None:
             self._nlp.Defaults.stop_words = set(config.preprocessing.stopwords)
         self._nlp.tokenizer = tokenizer(self._nlp, config)
@@ -47,6 +66,9 @@ class Pipe(object):
         self.config = config
         # Set log level
         logger.setLevel(self.config.general.log_level)
+
+    def _init_nlp(selef, config: Config) -> Language:
+        return spacy.load(config.general.spacy_model, disable=config.general.spacy_disabled_components)
 
     def add_tagger(self, tagger: Callable, name: Optional[str] = None, additional_fields: List[str] = []) -> None:
         """Add any kind of a tagger for tokens.

--- a/medcat/pipe.py
+++ b/medcat/pipe.py
@@ -57,7 +57,6 @@ class Pipe(object):
             # medcat.utils.normalizers.TokenNormalizer.__init__
             config.general.spacy_model = DEFAULT_SPACY_MODEL
             self._nlp = self._init_nlp(config)
-            print("TYPE", type(self._nlp))
         if config.preprocessing.stopwords is not None:
             self._nlp.Defaults.stop_words = set(config.preprocessing.stopwords)
         self._nlp.tokenizer = tokenizer(self._nlp, config)


### PR DESCRIPTION
There can be issues when a model doesn't ship with a working `spacy` model. So far, in those cases, the `Pipe` creation fails.

What this PR does is allow a fallback to the per-requirement installed `en_core_web_md` spacy model if there's an issue loading the spacy model that is shipped with the model pack. The issue could be that the sapcy model wasn't packed with the model or that the spacy model isn't compatible with the currently installed `spacy` version.

Along with using a fallback, the PR also generates a warning for the library user to know that they'd be better off shipping with a working spacy model.

