### PR TITLE
CU-8693cv3w0 Fix fallback spacy model existance on pip installs

### DIFF
--- a/medcat/pipe.py
+++ b/medcat/pipe.py
@@ -17,6 +17,7 @@ from medcat.config import Config
 from medcat.pipeline.pipe_runner import PipeRunner
 from medcat.preprocessing.taggers import tag_skip_and_punct
 from medcat.ner.transformers_ner import TransformersNER
+from medcat.utils.helpers import ensure_spacy_model
 
 
 logger = logging.getLogger(__name__) # different logger from the package-level one
@@ -55,6 +56,7 @@ class Pipe(object):
             # we're changing the config value so that this propages
             # to other places that try to load the model. E.g:
             # medcat.utils.normalizers.TokenNormalizer.__init__
+            ensure_spacy_model(DEFAULT_SPACY_MODEL)
             config.general.spacy_model = DEFAULT_SPACY_MODEL
             self._nlp = self._init_nlp(config)
         if config.preprocessing.stopwords is not None:

--- a/medcat/utils/helpers.py
+++ b/medcat/utils/helpers.py
@@ -566,4 +566,6 @@ def ensure_spacy_model(model_name: str) -> None:
     # running in subprocess so that we can catch the exception
     # if the model name is unknown. Otherwise we'd just be bumped
     # out of python (sys.exit).
+    logger.info("Installing the spacy model %s using the CLI command "
+                "'python -m spacy download %s'", model_name, model_name)
     subprocess.run(["python", "-m", "spacy", "download", model_name], check=True)

--- a/medcat/utils/helpers.py
+++ b/medcat/utils/helpers.py
@@ -537,3 +537,33 @@ def has_new_spacy() -> bool:
     return (major > 3 or
             (major == 3 and minor > 3) or
             (major == 3 and minor == 3 and patch >= 1))
+
+
+def has_spacy_model(model_name: str) -> bool:
+    """Checks if the spacy model is available.
+
+    Args:
+        model_name (str): The model name.
+
+    Returns:
+        bool: True if the model is available, False otherwise.
+    """
+    import spacy.util
+    return model_name in spacy.util.get_installed_models()
+
+
+def ensure_spacy_model(model_name: str) -> None:
+    """Ensure the specified spacy model exists.
+
+    If the model does not currently exist, it will attempt downloading it.
+
+    Args:
+        model_name (str): The spacy model name.
+    """
+    import subprocess
+    if has_spacy_model(model_name):
+        return
+    # running in subprocess so that we can catch the exception
+    # if the model name is unknown. Otherwise we'd just be bumped
+    # out of python (sys.exit).
+    subprocess.run(["python", "-m", "spacy", "download", model_name], check=True)

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,0 +1,24 @@
+from medcat.utils.helpers import has_spacy_model, ensure_spacy_model
+from medcat.pipe import DEFAULT_SPACY_MODEL
+
+import unittest
+import subprocess
+
+
+class HasSpacyModelTests(unittest.TestCase):
+
+    def test_no_rubbish_model(self, model_name='rubbish_model'):
+        self.assertFalse(has_spacy_model(model_name))
+
+    def test_has_def_model(self, model_name=DEFAULT_SPACY_MODEL):
+        self.assertTrue(has_spacy_model(model_name))
+
+
+class EnsureSpacyModelTests(unittest.TestCase):
+
+    def test_fails_rubbish_model(self, model_name='rubbish_model'):
+        with self.assertRaises(subprocess.CalledProcessError):
+            ensure_spacy_model(model_name)
+
+    def test_success_def_model(self, model_name=DEFAULT_SPACY_MODEL):
+        ensure_spacy_model(model_name)


### PR DESCRIPTION
When installing medcat using `pip install medcat`, the default spacy model (`en_core_web_md`) does not get installed.
That is because while it is specified in `requirements.txt` and `requirements-dev.txt`, it would need to be specified in `setup.py`'s `install_requires` in order to be shipped with the dependency.

As such, we're left with two options:
1. Add the dependency to `install_requires`
2. Download the model when falling back to default model and it isn't available

I've chosen the latter option.
To that end, I've added:
- A method to detect whether a specific spacy model is installed
- A method to ensure a specific spacy model is installed
- A few tests for the above
