### PR TITLE
CU-8693ftbyx: Make GH pre-release tag apply for PyPI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,11 +37,6 @@ jobs:
 
   publish-to-test-pypi:
 
-    if: |
-      github.repository == 'CogStack/MedCAT' &&
-      github.ref == 'refs/heads/master' &&
-      github.event_name == 'push' &&
-      startsWith(github.ref, 'refs/tags') != true
     runs-on: ubuntu-20.04
     concurrency: publish-to-test-pypi
     needs: [build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,12 +73,12 @@ jobs:
 
       - name: Determine if it's a pre-release
         id: check_prerelease
-        # run: echo ::set-output name=is_prerelease::${{ github.event.release.prerelease }}
+        # run: echo "IS_PRERELEASE=${{ github.event.release.prerelease }}" >> $GITHUB_ENV
         # NOTE: For the sake of normal workflow, all releases are pre-releases.
         #       The idea is that if the pre-release works, so does the regular release.
         #       The other option would be to run for pre-release and regular release
         #       but the trivial version for that would duplicate a bunch of the YAML.
-        run: echo ::set-output name=is_prerelease::true
+        run: echo "IS_PRERELEASE=true" >> $GITHUB_ENV
 
       - name: Build a binary wheel and a source tarball
         run: >-
@@ -93,6 +93,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          prerelease: ${{ steps.check_prerelease.outputs.is_prerelease == 'true' }}
+          prerelease: ${{ env.IS_PRERELEASE == 'true' }}
           repository_url: https://test.pypi.org/legacy/
         continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,15 @@ jobs:
           "s/node-and-date/no-local-version/g"
           setup.py
 
+      - name: Determine if it's a pre-release
+        id: check_prerelease
+        # run: echo ::set-output name=is_prerelease::${{ github.event.release.prerelease }}
+        # NOTE: For the sake of normal workflow, all releases are pre-releases.
+        #       The idea is that if the pre-release works, so does the regular release.
+        #       The other option would be to run for pre-release and regular release
+        #       but the trivial version for that would duplicate a bunch of the YAML.
+        run: echo ::set-output name=is_prerelease::true
+
       - name: Build a binary wheel and a source tarball
         run: >-
           python -m
@@ -78,11 +87,13 @@ jobs:
           --sdist
           --wheel
           --outdir dist/
+          ${{ steps.check_prerelease.outputs.is_prerelease == 'true' && '--pre' || '' }}
           .
 
       - name: Publish dev distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          prerelease: ${{ steps.check_prerelease.outputs.is_prerelease == 'true' }}
           repository_url: https://test.pypi.org/legacy/
         continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,11 @@ jobs:
 
   publish-to-test-pypi:
 
+    if: |
+      github.repository == 'CogStack/MedCAT' &&
+      github.ref == 'refs/heads/master' &&
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags') != true
     runs-on: ubuntu-20.04
     concurrency: publish-to-test-pypi
     needs: [build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,6 @@ jobs:
           --sdist
           --wheel
           --outdir dist/
-          ${{ steps.check_prerelease.outputs.is_prerelease == 'true' && '--pre' || '' }}
           .
 
       - name: Publish dev distribution to Test PyPI

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,6 @@ jobs:
 
   publish-to-test-pypi:
 
-    if: |
-      github.repository == 'CogStack/MedCAT' &&
-      github.event_name == 'push'
     runs-on: ubuntu-20.04
     concurrency: publish-to-test-pypi
     needs: [build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
 
     if: |
       github.repository == 'CogStack/MedCAT' &&
+      github.ref == 'refs/heads/master' &&
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags') != true
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,7 @@ jobs:
 
     if: |
       github.repository == 'CogStack/MedCAT' &&
-      github.event_name == 'push' &&
-      startsWith(github.ref, 'refs/tags') != true
+      github.event_name == 'push'
     runs-on: ubuntu-20.04
     concurrency: publish-to-test-pypi
     needs: [build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,8 @@ jobs:
 
     if: |
       github.repository == 'CogStack/MedCAT' &&
-      github.event_name == 'push'
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags') != true
     runs-on: ubuntu-20.04
     concurrency: publish-to-test-pypi
     needs: [build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
 
   publish-to-test-pypi:
 
+    if: |
+      github.repository == 'CogStack/MedCAT' &&
+      github.event_name == 'push'
     runs-on: ubuntu-20.04
     concurrency: publish-to-test-pypi
     needs: [build]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,6 @@ jobs:
 
     if: |
       github.repository == 'CogStack/MedCAT' &&
-      github.ref == 'refs/heads/master' &&
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags') != true
     runs-on: ubuntu-20.04

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -49,6 +49,7 @@ jobs:
           --wheel
           --outdir dist/
           ${{ steps.check_prerelease.outputs.is_prerelease == 'true' && '--pre' || '' }}
+          .
 
       - name: Publish production distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -48,7 +48,6 @@ jobs:
           --sdist
           --wheel
           --outdir dist/
-          ${{ steps.check_prerelease.outputs.is_prerelease == 'true' && '--pre' || '' }}
           .
 
       - name: Publish production distribution to PyPI

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -37,6 +37,10 @@ jobs:
           build
           --user
 
+      - name: Determine if it's a pre-release
+        id: check_prerelease
+        run: echo ::set-output name=is_prerelease::${{ github.event.release.prerelease }}
+
       - name: Build a binary wheel and a source tarball
         run: >-
           python -m
@@ -44,10 +48,11 @@ jobs:
           --sdist
           --wheel
           --outdir dist/
-          .
+          ${{ steps.check_prerelease.outputs.is_prerelease == 'true' && '--pre' || '' }}
 
       - name: Publish production distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          prerelease: ${{ steps.check_prerelease.outputs.is_prerelease == 'true' }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Determine if it's a pre-release
         id: check_prerelease
-        run: echo ::set-output name=is_prerelease::${{ github.event.release.prerelease }}
+        run: echo "IS_PRERELEASE=${{ github.event.release.prerelease }}" >> $GITHUB_ENV
 
       - name: Build a binary wheel and a source tarball
         run: >-
@@ -55,4 +55,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-          prerelease: ${{ steps.check_prerelease.outputs.is_prerelease == 'true' }}
+          prerelease: ${{ env.IS_PRERELEASE == 'true' }}


### PR DESCRIPTION
Currently when drafting a release on GitHub and marking it as a pre-release, it gets sent to PyPI as a full release rather than a pre-release.

This PR attempts to fix that by
 - Checking if the release is a pre-release
 - If it is, pass it on to PyPI as such

PS:
I don't really know how to test the change. I just put it together from example online.