### PR TITLE
add: metacat can predict on spans in arbitrary spangroups

### DIFF
--- a/medcat/config_meta_cat.py
+++ b/medcat/config_meta_cat.py
@@ -38,7 +38,7 @@ class General(MixingConfig, BaseModel):
     pipe_batch_size_in_chars: int = 20000000
     """How many characters are piped at once into the meta_cat class"""
     span_group: Optional[str] = None
-    """If set, the spacy span group that the metacat model will assign annotaitons. 
+    """If set, the spacy span group that the metacat model will assign annotations. 
     Otherwise defaults to doc._.ents or doc.ents per the annotate_overlapping settings"""
 
     class Config:

--- a/medcat/config_meta_cat.py
+++ b/medcat/config_meta_cat.py
@@ -38,6 +38,8 @@ class General(MixingConfig, BaseModel):
     pipe_batch_size_in_chars: int = 20000000
     """How many characters are piped at once into the meta_cat class"""
     span_group: Optional[str] = None
+    """If set, the spacy span group that the metacat model will assign annotaitons. 
+    Otherwise defaults to doc._.ents or doc.ents per the annotate_overlapping settings"""
 
     class Config:
         extra = Extra.allow

--- a/medcat/config_meta_cat.py
+++ b/medcat/config_meta_cat.py
@@ -37,6 +37,7 @@ class General(MixingConfig, BaseModel):
     a deployment."""
     pipe_batch_size_in_chars: int = 20000000
     """How many characters are piped at once into the meta_cat class"""
+    span_group: Optional[str] = None
 
     class Config:
         extra = Extra.allow

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -357,10 +357,13 @@ class MetaCAT(PipeRunner):
 
         return meta_cat
     
-    def get_ents(self, doc: Doc) -> List[Span]:
-        span_group_name = self.config.general.span_group
-        if span_group_name:
-            return doc.spans[span_group_name]
+    def get_ents(self, doc: Doc) -> Iterable[Span]:
+        spangroup_name = self.config.general.span_group
+        if spangroup_name:
+            try:
+                return doc.spans[spangroup_name]
+            except KeyError:
+                raise Exception(f"Configuration error MetaCAT was configured to set meta_anns on {spangroup_name} but this spangroup was not set on the doc.")
 
         # Should we annotate overlapping entities
         if self.config.general['annotate_overlapping']:

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -356,7 +356,7 @@ class MetaCAT(PipeRunner):
         meta_cat.model.load_state_dict(torch.load(model_save_path, map_location=device))
 
         return meta_cat
-    
+
     def get_ents(self, doc: Doc) -> Iterable[Span]:
         spangroup_name = self.config.general.span_group
         if spangroup_name:

--- a/tests/test_meta_cat.py
+++ b/tests/test_meta_cat.py
@@ -7,7 +7,8 @@ from transformers import AutoTokenizer
 from medcat.meta_cat import MetaCAT
 from medcat.config_meta_cat import ConfigMetaCAT
 from medcat.tokenizers.meta_cat_tokenizers import TokenizerWrapperBERT
-
+import spacy
+from spacy.tokens import Span
 
 class MetaCATTests(unittest.TestCase):
 
@@ -19,7 +20,7 @@ class MetaCATTests(unittest.TestCase):
         config.train['nepochs'] = 1
         config.model['input_size'] = 100
 
-        cls.meta_cat = MetaCAT(tokenizer=tokenizer, embeddings=None, config=config)
+        cls.meta_cat: MetaCAT = MetaCAT(tokenizer=tokenizer, embeddings=None, config=config)
 
         cls.tmp_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp")
         os.makedirs(cls.tmp_dir, exist_ok=True)
@@ -43,6 +44,33 @@ class MetaCATTests(unittest.TestCase):
         n_f1 = n_meta_cat.eval(json_path)['f1']
 
         self.assertEqual(f1, n_f1)
+
+    def test_predict_spangroup(self):
+        Span.set_extension('id', default=0, force=True)
+        Span.set_extension('meta_anns', default=None, force=True)
+
+
+        json_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources', 'mct_export_for_meta_cat_test.json')
+        self.meta_cat.train(json_path, save_dir_path=self.tmp_dir)
+        self.meta_cat.save(self.tmp_dir)
+        n_meta_cat = MetaCAT.load(self.tmp_dir)
+        assert n_meta_cat.config.general.span_group is None 
+
+        spangroup_name = 'predict_spangroup'
+        n_meta_cat.config.general.span_group = spangroup_name
+        nlp = spacy.blank("en")
+        doc = nlp("No history of diabetes.")
+        span = doc.char_span(14, 22, label="foo_spantype")
+        assert span.text == 'diabetes'
+        doc.spans[spangroup_name] = [span]
+        doc = n_meta_cat(doc)
+
+        # set back to None
+        n_meta_cat.config.general.span_group = None
+        assert doc.spans[spangroup_name][0]._.meta_anns['Status']['value'] == 'Affirmed'
+
+
+
 
 
 if __name__ == '__main__':

--- a/tests/test_meta_cat.py
+++ b/tests/test_meta_cat.py
@@ -45,32 +45,49 @@ class MetaCATTests(unittest.TestCase):
 
         self.assertEqual(f1, n_f1)
 
-    def test_predict_spangroup(self):
+    def _prepare_doc_w_spangroup(self, spangroup_name: str):
+        """
+        Create spans under an arbitrary spangroup key
+        """
         Span.set_extension('id', default=0, force=True)
         Span.set_extension('meta_anns', default=None, force=True)
+        nlp = spacy.blank("en")
+        doc = nlp("Pt has diabetes and copd.")
+        span_0 = doc.char_span(7,15, label="diabetes")
+        assert span_0.text == 'diabetes'
 
+        span_1 = doc.char_span(20,24, label="copd")
+        assert span_1.text == 'copd'
+        doc.spans[spangroup_name] = [span_0, span_1]
+        return doc
 
+    def test_predict_spangroup(self):
         json_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources', 'mct_export_for_meta_cat_test.json')
         self.meta_cat.train(json_path, save_dir_path=self.tmp_dir)
         self.meta_cat.save(self.tmp_dir)
         n_meta_cat = MetaCAT.load(self.tmp_dir)
-        assert n_meta_cat.config.general.span_group is None 
 
-        spangroup_name = 'predict_spangroup'
+        spangroup_name = "mock_span_group"
         n_meta_cat.config.general.span_group = spangroup_name
-        nlp = spacy.blank("en")
-        doc = nlp("No history of diabetes.")
-        span = doc.char_span(14, 22, label="foo_spantype")
-        assert span.text == 'diabetes'
-        doc.spans[spangroup_name] = [span]
+
+        doc = self._prepare_doc_w_spangroup(spangroup_name)
         doc = n_meta_cat(doc)
+        spans = doc.spans[spangroup_name]
+        self.assertEqual(len(spans), 2)
 
-        # set back to None
+        # All spans are annotate
+        for span in spans:
+            self.assertEqual(span._.meta_anns['Status']['value'], "Affirmed")
+
+        # Informative error if spangroup is not set
+        doc = self._prepare_doc_w_spangroup("foo")
+        n_meta_cat.config.general.span_group = "bar"
+        try:
+            doc = n_meta_cat(doc)
+        except Exception as error:
+            self.assertIn("Configuration error", str(error))
+
         n_meta_cat.config.general.span_group = None
-        assert doc.spans[spangroup_name][0]._.meta_anns['Status']['value'] == 'Affirmed'
-
-
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello - I opened this PR request to start a discussion about adding a new feature that allows a trained MetaCAT model to run on arbitrary spangroup. This will will allow configuring a MetaCAT model such that it can be pointed at an arbitrary spacy span group and set meta_anns on it.

Currently, it is allowed to run on the two set of `list[spacy.token.Span]`: `doc.ents` or `doc._.ents`.

However, there are use cases where we may store other spans as part of a pipeline under `doc.spans["my_spangroup_name"]` that are distinct from doc.ents in which we want to call predict on the meta cat model.

I don't think it's yet necessary to be able to train on arbitrary spangroups since that would get into changing the input format or extract format from medcat trainer.

One workaround is to either zero out the ents object and set the spangroup to those ents and call predict however this starts to feel hacky.

Another workaround is to create a duplicate `spacy.token.Doc` object and using `doc.ents` for the separate spangroup. However this is inefficient as it requires running parts of the spacy pipeline again and means we can't use this spangroup in other pipeline components.