### PR TITLE
CU-8693kp0gw: Pin more recent versions for major dependencies; Avoid major bumps where applicable

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 .
-https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.4.0/en_core_web_md-3.4.0-py3-none-any.whl
+https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.6.0/en_core_web_md-3.6.0-py3-none-any.whl
 flake8==4.0.1
 mypy==1.0.0
 mypy-extensions==0.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 .
-https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.4.0/en_core_web_md-3.4.0-py3-none-any.whl
+https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.6.0/en_core_web_md-3.6.0-py3-none-any.whl

--- a/setup.py
+++ b/setup.py
@@ -18,18 +18,18 @@ setuptools.setup(
               'medcat.tokenizers', 'medcat.utils.meta_cat', 'medcat.pipeline', 'medcat.utils.ner',
               'medcat.utils.saving', 'medcat.utils.regression', 'medcat.stats'],
     install_requires=[
-        'numpy>=1.22.0', # first to support 3.11
+        'numpy>=1.22.0,<1.26.0',  # 1.22.0 is first to support python 3.11; post 1.26.0 there's issues with scipy
         'pandas>=1.4.2', # first to support 3.11
-        'gensim>=4.3.0', # first to support 3.11
-        'spacy>=3.1.0',
-        'scipy~=1.9.2', # first to support 3.11
-        'transformers>=4.34.0',
+        'gensim>=4.3.0,<5.0.0',  # 5.3.0 is first to support 3.11; avoid major version bump
+        'spacy>=3.6.0,<4.0.0',  # Some later model packs (e.g HPO) are made with 3.6.0 spacy model; avoid major version bump
+        'scipy~=1.9.2',  # 1.9.2 is first to support 3.11
+        'transformers>=4.34.0,<5.0.0',  # avoid major version bump
         'accelerate>=0.23.0', # required by Trainer class in de-id
-        'torch>=1.13.0', # first to support 3.11
+        'torch>=1.13.0,<3.0.0', # 1.13 is first to support 3.11; 2.1.2 has been compatible, but avoid major 3.0.0 for now
         'tqdm>=4.27',
-        'scikit-learn>=1.1.3', # first to supporrt 3.11
-        'dill>=0.3.4', # allow later versions with later versions of datasets (tested with 0.3.6)
-        'datasets>=2.2.2', # allow later versions, tested with 2.7.1
+        'scikit-learn>=1.1.3,<2.0.0',  # 1.1.3 is first to supporrt 3.11; avoid major version bump
+        'dill>=0.3.6,<1.0.0', # stuff saved in 0.3.6/0.3.7 is not always compatible with 0.3.4/0.3.5; avoid major bump
+        'datasets>=2.2.2,<3.0.0', # avoid major bump
         'jsonpickle>=2.0.0', # allow later versions, tested with 3.0.0
         'psutil>=5.8.0',
         # 0.70.12 uses older version of dill (i.e less than 0.3.5) which is required for datasets

--- a/tests/resources/ff_core_fake_dr/meta.json
+++ b/tests/resources/ff_core_fake_dr/meta.json
@@ -4,5 +4,5 @@
     "version":"3.1.0",
     "description":"This is a FAKE model",
     "author":"Fakio Martimus",
-    "spacy_version":">=3.1.0,<3.2.0"
+    "spacy_version":">=3.1.0,<4.0.0"
   }

--- a/tests/test_ner.py
+++ b/tests/test_ner.py
@@ -67,8 +67,7 @@ class A_NERTests(unittest.TestCase):
         cls.pipe.destroy()
 
     def test_aa_cdb_names_output(self):
-        print("Fixing 'movar~viruse' -> 'movar-virus' for newere en_core_web_md")
-        target_result = {'S-229004': {'movar~virus', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}
+        target_result = {'S-229004': {'movar~viruse', 'movar', 'movar~viruses'}, 'S-229005': {'cdb'}}
         self.assertEqual(self.cdb.cui2names, target_result)
 
     def test_ab_entities_length(self):

--- a/tests/utils/test_spacy_compatibility.py
+++ b/tests/utils/test_spacy_compatibility.py
@@ -149,7 +149,7 @@ class GetSpacyModelInfoTests(unittest.TestCase):
 
 
 class GetSpacyModelVersionTests(GetSpacyModelInfoTests):
-    expected_spacy_version = ">=3.1.0,<3.2.0"
+    expected_spacy_version = ">=3.1.0,<4.0.0"
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -253,9 +253,9 @@ class ModelPackHasCompatibleSpacyRangeTests(unittest.TestCase):
             self.assertTrue(b)
 
 class ModelPackHasInCompatibleSpacyRangeTests(unittest.TestCase):
-    test_spacy_version = "3.2.0"
+    test_spacy_version = "3.0.0"
 
-    def test_is_in_range(self):
+    def test_is_not_in_range(self):
         with custom_spacy_version(self.test_spacy_version):
             b = medcat_model_pack_has_compatible_spacy_model(FAKE_MODELPACK_MODEL_DIR)
             self.assertFalse(b)


### PR DESCRIPTION
There's can be some issues with dependency versions.

This is mostly with respect to `spacy` and `dill`. In essence, we've been depending on higher versions than that defined in `setup.py`.
This is because by default a significantly higher version of `spacy` is installed compared to the low end of the requirement.
And some things saved with `dill>=0.3.6` are not readable with `0.3.4` and `0.3.5`.

However, if one were to upgrade from an older version of `medcat`, if the dependency range allows the current version of a dependency (e.g `spacy` or `dill`), pip will not upgrade it. As such, one might arrive with an incompatible state of dependencies even for models created and/or saved in the same `medcat` version.

The motivation for this change is as follows:
- Some newer models (in my case, the HPO model, specifically) use the `en_core_web_md` model version `3.6.0`. However, that is not compatible with `spacy<3.6.0`.
- Models saved in newer versions of `medcat` may have been saved with `dill>=0.3.6`. As such, they would not be readable if trying to do so with `dill<0.3.6`.

This PR:
- Bumps the minimum requirement for `spacy` from `3.1.0` to `3.6.0` (inclusive)
  - Bumps the default spacy model (`en_core_web_md`) to `3.6.0`
- Bumps the minimum requirement for `dill` from `0.3.4` to `0.3.6` (inclusive)
- Restricts many of the important dependencies to the current major version
  - To avoid pip pulling in new major versions with breaking changes one day
  - This has already happened in the past with `pydantic==2.0.0`
- Documents the reasons for most of the pins to the best of my ability