### PR TITLE
CU-8693t24ed: Add workaround for older DeID models in newer MedCAT

### DIFF
--- a/medcat/ner/transformers_ner.py
+++ b/medcat/ner/transformers_ner.py
@@ -79,6 +79,9 @@ class TransformersNER(object):
 
     def create_eval_pipeline(self):
         self.ner_pipe = pipeline(model=self.model, task="ner", tokenizer=self.tokenizer.hf_tokenizer)
+        # NOTE: this will fix the DeID model(s) created before medcat 1.9.3
+        #       though this fix may very well be unstable
+        self.ner_pipe.tokenizer._in_target_context_manager = False
         self.ner_pipe.device = self.model.device
 
     def get_hash(self):

--- a/medcat/ner/transformers_ner.py
+++ b/medcat/ner/transformers_ner.py
@@ -79,9 +79,10 @@ class TransformersNER(object):
 
     def create_eval_pipeline(self):
         self.ner_pipe = pipeline(model=self.model, task="ner", tokenizer=self.tokenizer.hf_tokenizer)
-        # NOTE: this will fix the DeID model(s) created before medcat 1.9.3
-        #       though this fix may very well be unstable
-        self.ner_pipe.tokenizer._in_target_context_manager = False
+        if not hasattr(self.ner_pipe.tokenizer, '_in_target_context_manager'):
+            # NOTE: this will fix the DeID model(s) created before medcat 1.9.3
+            #       though this fix may very well be unstable
+            self.ner_pipe.tokenizer._in_target_context_manager = False
         self.ner_pipe.device = self.model.device
 
     def get_hash(self):


### PR DESCRIPTION
In `medcat==1.9.3` there was a change to the `transformers` dependency range (from `transformers>=4.19.2,<4.22.0` to `transformers>=4.34.0`). That change also removed the comment that the pin was for the DeID model to work.

I've looked into the issue and believe I've got a workaround for it.
The newer versions of transformers (starting rom `4.22.0`) expect the tokenizer to have a specific attribute (`_in_target_context_manager`). However, as we load it off disk, the attribute doesn't exist since the saved version is older.
The change reference:
https://github.com/huggingface/transformers/pull/18325

So what this PR does is add the missing attribute to the tokenizer.
I've tested locally with the DeID model and after this change, it worked just fine.

PS:
This isn't really easy to test automatically. The only way we could do that would be to include (or potentially download during test time) an older DeID model. But I don't want to clutter the repo with that.