### PR TITLE
CU-8693ruk7p: Bump mypy version in dev-requirements (#396)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 .
 https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.6.0/en_core_web_md-3.6.0-py3-none-any.whl
 flake8==4.0.1
-mypy==1.0.0
-mypy-extensions==0.4.3
+mypy>=1.7.0,<2.0.0
+mypy-extensions>=1.0.0
 types-aiofiles==0.8.3
 types-PyYAML==6.0.3
 types-setuptools==57.4.10


### PR DESCRIPTION
* CU-8693ruk7p: Bump mypy version (along with extensions) in dev-requirements

* CU-8693ruk7p: Pin max major version for mypy