### PR TITLE
v1.10.1 PR (attempt 2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Test
         run: |
           timeout 17m python -m unittest discover
-        continue-on-error: true
 
   publish-to-test-pypi:
 

--- a/medcat/config_meta_cat.py
+++ b/medcat/config_meta_cat.py
@@ -38,7 +38,7 @@ class General(MixingConfig, BaseModel):
     pipe_batch_size_in_chars: int = 20000000
     """How many characters are piped at once into the meta_cat class"""
     span_group: Optional[str] = None
-    """If set, the spacy span group that the metacat model will assign annotations. 
+    """If set, the spacy span group that the metacat model will assign annotations.
     Otherwise defaults to doc._.ents or doc.ents per the annotate_overlapping settings"""
 
     class Config:

--- a/tests/utils/ner/test_deid.py
+++ b/tests/utils/ner/test_deid.py
@@ -154,6 +154,13 @@ class DeIDModelMultiprocessingWorks(unittest.TestCase):
         for project in raw_data['projects']:
             for doc in project['documents']:
                 cls.data.append((f"{project['name']}_{doc['name']}", doc['text']))
+        # NOTE: Comment and subsequent code
+        #       copied from CAT.multiprocessing_batch_char_size
+        #       (lines 1234 - 1237)
+        # Hack for torch using multithreading, which is not good if not
+        #separate_nn_components, need for CPU runs only
+        import torch
+        torch.set_num_threads(1)
 
     def assertTextHasBeenDeIded(self, text: str, redacted: bool):
         if not redacted:


### PR DESCRIPTION
* CU-8693u6b4u: Make sure failed/errored tests fail the main workflow

* CU-8693u6b4u: Attempt to fix deid multiprocessing, at least for GHA

* CU-8693u6b4u: Fix small docstring issue