### PR TITLE
CU-8693v6epd: Move typing imports away from pydantic

### DIFF
--- a/medcat/config.py
+++ b/medcat/config.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 from pydantic import BaseModel, Extra, ValidationError
-from pydantic.dataclasses import Any, Callable, Dict, Optional, Union
 from pydantic.fields import ModelField
-from typing import List, Set, Tuple, cast
+from typing import List, Set, Tuple, cast, Any, Callable, Dict, Optional, Union
 from multiprocessing import cpu_count
 import logging
 import jsonpickle


### PR DESCRIPTION
The config had imports typing helpers (`Any`, Callable , Dict ,`Optional`, `Union` ) from `pydantic.dataclasses` instead of directly from `typing` .
Most likely an automatic import that I forgot to fix at the time.

Making sure to import from the proper package.