### PR TITLE
De id chunking

### DIFF
--- a/medcat/config_transformers_ner.py
+++ b/medcat/config_transformers_ner.py
@@ -15,6 +15,8 @@ class General(MixingConfig, BaseModel):
     """Agg strategy for HF pipeline for NER"""
     test_size: float = 0.2
     last_train_on: Optional[int] = None
+    maximum_tokens_model: Optional[int] = 510
+    """Maxiumum number of tokens to be passed to the model"""
     verbose_metrics: bool = False
 
     class Config:

--- a/medcat/utils/ner/chunking.py
+++ b/medcat/utils/ner/chunking.py
@@ -4,6 +4,7 @@ import re
 import logging
 
 logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.WARNING)
 
 MAX_TOKENS_ROBERTA = 510
 

--- a/medcat/utils/ner/chunking.py
+++ b/medcat/utils/ner/chunking.py
@@ -27,7 +27,7 @@ def get_chunks(text:str, tokenizer, config: Optional[ConfigTransformersNER] = No
         return get_chunks_roberta(text, tokenizer, config)
     else:
         logger.warning(
-            "Chunking functionality is implemented for RoBERTa models. The detected model is not RoBERTa, so chunking is omitted. Be cautious, as PII information MAY BE REVEALED.")
+            "Chunking functionality is implemented for RoBERTa models. The detected model is not RoBERTa, so chunking is omitted. Be cautious, as PII data MAY BE REVEALED.")
         return [text]
 
 

--- a/medcat/utils/ner/chunking.py
+++ b/medcat/utils/ner/chunking.py
@@ -1,0 +1,73 @@
+from medcat.config_transformers_ner import ConfigTransformersNER
+from typing import Union, Tuple, Any, List, Iterable, Optional
+import re
+import logging
+
+logger = logging.getLogger(__name__)
+
+MAX_TOKENS_ROBERTA = 510
+
+def get_chunks(text:str, tokenizer, config: ConfigTransformersNER = None) -> List[str]:
+    """Chunking class for De_Id
+
+    This utility is to be used with the De_Id wrapper to create chunks of input text.
+    It provides methods for creating chunks based on the NER model used.
+
+    """
+
+    if config is None:
+        config = ConfigTransformersNER()
+
+    if 'Roberta' in tokenizer.__class__.__name__:
+        return get_chunks_roberta(text, tokenizer, config)
+    else:
+        logger.warning(
+            "Chunking functionality is implemented for RoBERTa models. The detected model is not RoBERTa, so chunking is omitted. Be cautious, as PII information MAY BE REVEALED.")
+        return [text]
+
+def get_chunks_roberta(self, text:str, tokenizer, config: ConfigTransformersNER) -> List[str]:
+    """Create chunks from the given input text.
+
+       Args:
+           text (str): The text to deidentify.
+
+       Returns:
+           str: The deidentified text.
+   """
+
+    blocks: List[List[tuple]] = [[]]
+    if config.general['maximum_tokens_model']>510:
+        logger.warning(
+            "Number of tokens per chunk is greater than the limit for RoBERTa model. Reverted back to 510 tokens per chunk")
+
+    maximum_tkns = min(MAX_TOKENS_ROBERTA, config.general['maximum_tokens_model'])  # This is specific to RoBERTa model, with a maximum token limit is 512.
+    whitespace_pattern = re.compile(r'\s')
+    tok_output = tokenizer.encode_plus(text, return_offsets_mapping=True)
+    for token, (start, end) in zip(tok_output['input_ids'], tok_output['offset_mapping']):
+        if token in [0, 2]:
+            continue
+        if len(blocks[-1]) == maximum_tkns:
+            to_append_block = []
+            idx_chunk = -1
+            for i in range(len(blocks[-1]) - 1, len(blocks[-1]) - 21, -1):
+                # This method to avoid sub-word division is specific for RoBERTA's tokenizer (BPE)
+                if re.search(whitespace_pattern, tokenizer.decode(blocks[-1][i][0],clean_up_tokenization_spaces=False)):
+                    idx_chunk = i
+                    break
+
+            if idx_chunk != -1:
+                to_append_block.extend(blocks[-1][i:])
+                del blocks[-1][idx_chunk:]
+
+            to_append_block.append((token, (start, end)))
+            blocks.append(to_append_block)
+
+        else:
+            blocks[-1].append((token, (start, end)))
+
+    chunked_text: List = []
+    for block in blocks:
+        this_text = text[block[0][-1][0]:block[-1][-1][-1]]
+        chunked_text.append(this_text)
+
+    return chunked_text

--- a/medcat/utils/ner/chunking.py
+++ b/medcat/utils/ner/chunking.py
@@ -25,7 +25,7 @@ def get_chunks(text:str, tokenizer, config: ConfigTransformersNER = None) -> Lis
             "Chunking functionality is implemented for RoBERTa models. The detected model is not RoBERTa, so chunking is omitted. Be cautious, as PII information MAY BE REVEALED.")
         return [text]
 
-def get_chunks_roberta(self, text:str, tokenizer, config: ConfigTransformersNER) -> List[str]:
+def get_chunks_roberta(text:str, tokenizer, config: ConfigTransformersNER) -> List[str]:
     """Create chunks from the given input text.
 
        Args:

--- a/medcat/utils/ner/chunking.py
+++ b/medcat/utils/ner/chunking.py
@@ -1,5 +1,5 @@
 from medcat.config_transformers_ner import ConfigTransformersNER
-from typing import Union, Tuple, Any, List, Iterable, Optional
+from typing import List, Optional
 import re
 import logging
 
@@ -7,6 +7,7 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.WARNING)
 
 MAX_TOKENS_ROBERTA = 510
+
 
 def get_chunks(text:str, tokenizer, config: Optional[ConfigTransformersNER] = None) -> List[str]:
     """Chunking class for De_Id
@@ -29,8 +30,9 @@ def get_chunks(text:str, tokenizer, config: Optional[ConfigTransformersNER] = No
             "Chunking functionality is implemented for RoBERTa models. The detected model is not RoBERTa, so chunking is omitted. Be cautious, as PII information MAY BE REVEALED.")
         return [text]
 
+
 def get_chunks_roberta(text:str, tokenizer, config: ConfigTransformersNER) -> List[str]:
-    """Create chunks from the given input text.
+    """Create chunks from the given input text for Roberta model.
 
        Args:
            text (str): The text to deidentify.
@@ -53,7 +55,7 @@ def get_chunks_roberta(text:str, tokenizer, config: ConfigTransformersNER) -> Li
         if len(blocks[-1]) == maximum_tkns:
             to_append_block = []
             idx_chunk = -1
-            for i in range(len(blocks[-1]) - 1, len(blocks[-1]) - 21, -1):
+            for i in range(len(blocks[-1]) - 1, len(blocks[-1]) - 21, -1): # Checking back 20 tokens to ensure no sub-word division
                 # This method to avoid sub-word division is specific for RoBERTA's tokenizer (BPE)
                 if re.search(whitespace_pattern, tokenizer.decode(blocks[-1][i][0],clean_up_tokenization_spaces=False)):
                     idx_chunk = i

--- a/medcat/utils/ner/chunking.py
+++ b/medcat/utils/ner/chunking.py
@@ -8,11 +8,14 @@ logging.basicConfig(level=logging.WARNING)
 
 MAX_TOKENS_ROBERTA = 510
 
-def get_chunks(text:str, tokenizer, config: Union[ConfigTransformersNER, None] = None) -> List[str]:
+def get_chunks(text:str, tokenizer, config: Optional[ConfigTransformersNER] = None) -> List[str]:
     """Chunking class for De_Id
 
     This utility is to be used with the De_Id wrapper to create chunks of input text.
     It provides methods for creating chunks based on the NER model used.
+
+    v1: Changed to address the limit of 512 tokens. Added chunking - breaking down the document into mini-documents
+    v2 planned: Add overlapping window instead of a straight cut
 
     """
 
@@ -39,7 +42,7 @@ def get_chunks_roberta(text:str, tokenizer, config: ConfigTransformersNER) -> Li
     blocks: List[List[tuple]] = [[]]
     if config.general['maximum_tokens_model']>510:
         logger.warning(
-            "Number of tokens per chunk is greater than the limit for RoBERTa model. Reverted back to 510 tokens per chunk")
+            "Number of tokens per chunk is greater than the limit for RoBERTa model. Reverting back to default 510 tokens per chunk")
 
     maximum_tkns = min(MAX_TOKENS_ROBERTA, config.general['maximum_tokens_model'])  # This is specific to RoBERTa model, with a maximum token limit is 512.
     whitespace_pattern = re.compile(r'\s')

--- a/medcat/utils/ner/chunking.py
+++ b/medcat/utils/ner/chunking.py
@@ -8,7 +8,7 @@ logging.basicConfig(level=logging.WARNING)
 
 MAX_TOKENS_ROBERTA = 510
 
-def get_chunks(text:str, tokenizer, config: ConfigTransformersNER = None) -> List[str]:
+def get_chunks(text:str, tokenizer, config: Union[ConfigTransformersNER, None] = None) -> List[str]:
     """Chunking class for De_Id
 
     This utility is to be used with the De_Id wrapper to create chunks of input text.

--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -42,6 +42,7 @@ from medcat.utils.ner.model import NerModel
 from medcat.config_transformers_ner import ConfigTransformersNER
 from medcat.utils.ner.helpers import _deid_text as deid_text, replace_entities_in_text
 from medcat.utils.ner.chunking import get_chunks
+from spacy.pipeline.ner import EntityRecognizer
 
 class DeIdModel(NerModel):
     """The DeID model.
@@ -76,7 +77,7 @@ class DeIdModel(NerModel):
         Returns:
             str: The deidentified text.
         """
-
+        de_id_pipe: EntityRecognizer
         de_id_pipe = self.cat.pipe._nlp.get_pipe("deid")
         chunked_text = get_chunks(text,de_id_pipe.ner_pipe.tokenizer,config)
 

--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -77,6 +77,8 @@ class DeIdModel(NerModel):
 
         blocks = [[]]
         whitespace_pattern = re.compile(r'\s')
+        if config is None:
+            config = ConfigTransformersNER()
         maximum_tkns = min(510, config.general['maximum_tokens_model'])
         for name, proc in self.cat.pipe._nlp.pipeline:
             if name == 'deid':

--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -41,6 +41,7 @@ import warnings
 from medcat.utils.ner.model import NerModel
 from medcat.config_transformers_ner import ConfigTransformersNER
 from medcat.utils.ner.helpers import _deid_text as deid_text, replace_entities_in_text
+from medcat.utils.ner.chunking import get_chunks
 
 class DeIdModel(NerModel):
     """The DeID model.
@@ -62,46 +63,6 @@ class DeIdModel(NerModel):
               *args, **kwargs) -> Tuple[Any, Any, Any]:
         return super().train(json_path, *args, train_nr=0, **kwargs)  # type: ignore
 
-    def get_chunks(self, text:str, de_id_pipe,maximum_tkns) -> List[List[Any]]:
-
-        blocks = [[]]
-        if 'Roberta' in de_id_pipe.ner_pipe.tokenizer.__class__.__name__:
-
-            whitespace_pattern = re.compile(r'\s')
-            tok_output = de_id_pipe.ner_pipe.tokenizer(text, return_offsets_mapping=True)
-            for token, (start, end) in zip(tok_output['input_ids'], tok_output['offset_mapping']):
-                if token in [0, 2]:
-                    continue
-                if len(blocks[-1]) == maximum_tkns:
-                    to_append_block = []
-                    idx_chunk = -1
-                    for i in range(len(blocks[-1]) - 1, len(blocks[-1]) - 21, -1):
-                        # This method to avoid sub-word division is specific for RoBERTA's tokenizer (BPE)
-                        if re.search(whitespace_pattern, de_id_pipe.ner_pipe.tokenizer.decode(blocks[-1][i][0],clean_up_tokenization_spaces=False)):
-                            idx_chunk = i
-                            break
-
-                    if idx_chunk != -1:
-                        to_append_block.extend(blocks[-1][i:])
-                        del blocks[-1][idx_chunk:]
-
-                    to_append_block.append((token, (start, end)))
-                    blocks.append(to_append_block)
-
-                else:
-                    blocks[-1].append((token, (start, end)))
-
-        else:
-            # print("***********WARNING:************\nChunking functionality is implemented for RoBERTa model. The model detected is not RoBERTa, chunking omitted.\nPII information MAY BE REVEALED.")
-            warnings.warn("\n\nChunking functionality is implemented for RoBERTa models. The detected model is not RoBERTa, so chunking is omitted. Be cautious, as PII information MAY BE REVEALED.")
-            tok_output = de_id_pipe.ner_pipe.tokenizer(text, return_offsets_mapping=True)
-            for token, (start, end) in zip(tok_output['input_ids'], tok_output['offset_mapping']):
-                if token in [0, 2]:
-                    continue
-                blocks[-1].append((token, (start, end)))
-
-        return blocks
-
     def deid_text(self, text: str, redact: bool = False,config: Optional[ConfigTransformersNER] = None) -> str:
         """Deidentify text and potentially redact information.
 
@@ -116,16 +77,12 @@ class DeIdModel(NerModel):
             str: The deidentified text.
         """
 
-        if config is None:
-            config = ConfigTransformersNER()
-        maximum_tkns = min(510,config.general['maximum_tokens_model']) # This is specific to RoBERTa model, with a maximum token limit is 512.
         de_id_pipe = self.cat.pipe._nlp.get_pipe("deid")
+        chunked_text = get_chunks(text,de_id_pipe.ner_pipe.tokenizer,config)
 
-        blocks = self.get_chunks(text,de_id_pipe,maximum_tkns)
         anon_text = []
-        for block in blocks:
-            this_text = text[block[0][-1][0]:block[-1][-1][-1]]
-            anon_ = deid_text(self.cat, this_text, redact=redact)
+        for text_ in chunked_text:
+            anon_ = deid_text(self.cat, text_, redact=redact)
             anon_text.append(anon_)
 
         return " ".join(anon_text)

--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -35,9 +35,7 @@ The wrapper also exposes some CAT parts directly:
 - cdb
 """
 from typing import Union, Tuple, Any, List, Iterable, Optional
-import re
 from medcat.cat import CAT
-import warnings
 from medcat.utils.ner.model import NerModel
 from medcat.config_transformers_ner import ConfigTransformersNER
 from medcat.utils.ner.helpers import _deid_text as deid_text, replace_entities_in_text

--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -73,6 +73,7 @@ class DeIdModel(NerModel):
         v2: Changed to add support for chunking functionality 
 
         Args:
+            config: TransformersNER configuration containing the number of tokens per chunk
             text (str): The text to deidentify.
             redact (bool): Whether to redact the information.
 
@@ -82,13 +83,12 @@ class DeIdModel(NerModel):
         de_id_pipe: EntityRecognizer
         de_id_pipe = self.cat.pipe._nlp.get_pipe("deid")
         chunked_text = get_chunks(text,de_id_pipe.ner_pipe.tokenizer,config)
-
         anon_text = []
         for text_ in chunked_text:
             anon_ = deid_text(self.cat, text_, redact=redact)
             anon_text.append(anon_)
 
-        return " ".join(anon_text)
+        return "".join(anon_text)
 
     def deid_multi_texts(self,
                          texts: Union[Iterable[str], Iterable[Tuple]],
@@ -108,7 +108,7 @@ class DeIdModel(NerModel):
         Returns:
             List[str]: List of deidentified documents.
         """
-        logger.warning("Deidentify text on multiple does not include chunking functionality. Be cautions, as chunking is not utilised, PII data MAY BE REVEALED.")
+        logger.warning("Deidentify text on multiple does not include chunking functionality. Be cautious, as chunking is not utilised, PII data MAY BE REVEALED.")
         entities = self.cat.get_entities_multi_texts(texts, addl_info=addl_info,
                                                      n_process=n_process, batch_size=batch_size)
         out = []

--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -66,8 +66,7 @@ class DeIdModel(NerModel):
     def deid_text(self, text: str, redact: bool = False,config: Optional[ConfigTransformersNER] = None) -> str:
         """Deidentify text and potentially redact information.
 
-        v2: Changed to address the limit of 512 tokens. Adding chunking (break down the document into mini-documents and then run the model)
-        v3 planned: Add overlapping window instead of a straight cut
+        v2: Changed to add support for chunking functionality 
 
         Args:
             text (str): The text to deidentify.

--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -41,6 +41,10 @@ from medcat.config_transformers_ner import ConfigTransformersNER
 from medcat.utils.ner.helpers import _deid_text as deid_text, replace_entities_in_text
 from medcat.utils.ner.chunking import get_chunks
 from spacy.pipeline.ner import EntityRecognizer
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.WARNING)
 
 
 class DeIdModel(NerModel):
@@ -104,6 +108,7 @@ class DeIdModel(NerModel):
         Returns:
             List[str]: List of deidentified documents.
         """
+        logger.warning("Deidentify text on multiple does not include chunking functionality. Be cautions, as chunking is not utilised, PII data MAY BE REVEALED.")
         entities = self.cat.get_entities_multi_texts(texts, addl_info=addl_info,
                                                      n_process=n_process, batch_size=batch_size)
         out = []

--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -85,7 +85,7 @@ class DeIdModel(NerModel):
         chunked_text = get_chunks(text,de_id_pipe.ner_pipe.tokenizer,config)
         anon_text = []
         for text_ in chunked_text:
-            anon_ = deid_text(self.cat, text_, redact=redact)
+            anon_ = deid_text(self.cat, text_, redact=redact, chunk=False)
             anon_text.append(anon_)
 
         return "".join(anon_text)

--- a/medcat/utils/ner/deid.py
+++ b/medcat/utils/ner/deid.py
@@ -42,6 +42,7 @@ from medcat.utils.ner.helpers import _deid_text as deid_text, replace_entities_i
 from medcat.utils.ner.chunking import get_chunks
 from spacy.pipeline.ner import EntityRecognizer
 
+
 class DeIdModel(NerModel):
     """The DeID model.
 


### PR DESCRIPTION
Adding functionality for chunking documents that exceed the maximum number of tokens the model can process.
- Chunking done with straight cut, with measures taken to prevent sub-word division by implementing functionality to check for whitespace. 
- Added an attribute 'maximum_tokens_model' to the NER config to control the maximum number of tokens being passed (this has an upper limit of 510 to prevent issues down the road)