### PR TITLE
CU-86949zjg9 mp progress

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -1189,7 +1189,8 @@ class CAT(object):
                                         separate_nn_components: bool = True,
                                         out_split_size_chars: Optional[int] = None,
                                         save_dir_path: str = os.path.abspath(os.getcwd()),
-                                        min_free_memory=0.1) -> Dict:
+                                        min_free_memory=0.1,
+                                        enabled_progress_bar: bool = True) -> Dict:
         r"""Run multiprocessing for inference, if out_save_path and out_split_size_chars is used this will also continue annotating
         documents if something is saved in that directory.
 
@@ -1221,6 +1222,8 @@ class CAT(object):
                 should be a range between [0, 1] meaning how much of the memory has to be free. Helps when annotating
                 very large datasets because spacy is not the best with memory management and multiprocessing.
                 Defaults to 0.1.
+            enabled_progress_bar (bool):
+                Whether to enabled the progress bar. Defaults to True.
 
         Returns:
             Dict:
@@ -1261,10 +1264,10 @@ class CAT(object):
         # for progress bar
         if hasattr(data, '__len__'):  # Check if data has length
             total_docs = len(data)
-            iterator = tqdm(data, desc="Processing", unit="batch", total=total_docs)
+            iterator = tqdm(data, desc="Processing", unit="batch", total=total_docs, disable=not enabled_progress_bar)
         else:
             total_docs = None
-            iterator = tqdm(data, desc="Processing", unit="batch")
+            iterator = tqdm(data, desc="Processing", unit="batch", disable=not enabled_progress_bar)
 
         docs = {}
         _start_time = time.time()

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -1263,7 +1263,7 @@ class CAT(object):
 
         # for progress bar
         if hasattr(data, '__len__'):  # Check if data has length
-            total_docs = len(data)
+            total_docs = len(data)  # type: ignore
             iterator = tqdm(data, desc="Processing", unit="batch", total=total_docs, disable=not enabled_progress_bar)
         else:
             total_docs = None

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -1258,10 +1258,18 @@ class CAT(object):
             annotated_ids = []
             part_counter = 0
 
+        # for progress bar
+        if hasattr(data, '__len__'):  # Check if data has length
+            total_docs = len(data)
+            iterator = tqdm(data, desc="Processing", unit="batch", total=total_docs)
+        else:
+            total_docs = None
+            iterator = tqdm(data, desc="Processing", unit="batch")
+
         docs = {}
         _start_time = time.time()
         _batch_counter = 0 # Used for splitting the output, counts batches inbetween saves
-        for batch in self._batch_generator(data, batch_size_chars, skip_ids=set(annotated_ids)):
+        for batch in self._batch_generator(iterator, batch_size_chars, skip_ids=set(annotated_ids)):
             logger.info("Annotated until now: %s docs; Current BS: %s docs; Elapsed time: %.2f minutes",
                           len(annotated_ids),
                           len(batch),
@@ -1288,6 +1296,8 @@ class CAT(object):
                     del docs
                     docs = {}
                     _batch_counter = 0
+                if total_docs is not None:
+                    iterator.set_postfix({"Processed": len(annotated_ids), "Total": total_docs})
             except Exception as e:
                 logger.warning("Failed an outer batch in the multiprocessing script")
                 logger.warning(e, exc_info=True, stack_info=True)

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -61,18 +61,32 @@ class CATTests(unittest.TestCase):
     def test_callable_with_single_none_text(self):
         self.assertIsNone(self.undertest(None))
 
+    
+    in_data_mp = [
+        (1, "The dog is sitting outside the house and second csv."),
+        (2, ""),
+        (3, None)
+    ]
+
     def test_multiprocessing(self):
-        in_data = [
-            (1, "The dog is sitting outside the house and second csv."),
-            (2, ""),
-            (3, None)
-        ]
+        in_data = self.in_data_mp
+        self._helper_mp(in_data)
+    
+    def _helper_mp(self, in_data):
         out = self.undertest.multiprocessing_batch_char_size(in_data, nproc=1)
 
         self.assertEqual(3, len(out))
         self.assertEqual(1, len(out[1]['entities']))
         self.assertEqual(0, len(out[2]['entities']))
         self.assertEqual(0, len(out[3]['entities']))
+
+    def test_multiprocessing_with_generator(self):
+        # NOTE: generators won't have full use of 
+        #       the same progress bar functionality
+        #       but we're still hoping they would work in general
+        in_generator = (part for part in self.in_data_mp)
+        self._helper_mp(in_generator)
+
 
     def test_multiprocessing_pipe(self):
         in_data = [


### PR DESCRIPTION
Add progress bar to `CAT.multiprocessing_batch_char_size`.
If the data is given in something that has a length (i.e `list`, or `tuple`) it will be able to estimate the time left. Otherwise it just shows the time per batch (as per normal).

Also added option to disable the progress bar.

