### PR TITLE
Small addition to contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ When making changes to MedCAT, make sure you have the dependencies defined in [r
 Please make sure the code additions are adequately tested and well documented.
 
 Before submitting a pull request, please ensure that the changes satisfy following:
+- The changes are based on the `master` branch (i.e merge the master branch in before submitting a PR)
 - There are no issues with types/mypy (run `python -m mypy --follow-imports=normal medcat` in the project root)
 - There are no issues with flake8 (run `flake8 medcat` in the project root)
 - All tests are successful (run `python -m unittest discover` in the project root)


### PR DESCRIPTION
Just to explicitly mention the need to be in sync with the `master` branch.

Hasn't really been an issue, but I thought best to just mention it.