### PR TITLE
CU-8694cbcpu: Allow specifying an AU Snomed when preprocessing

### DIFF
--- a/medcat/utils/preprocess_snomed.py
+++ b/medcat/utils/preprocess_snomed.py
@@ -72,9 +72,10 @@ class Snomed:
         release (str): Release of SNOMED CT folder.
         uk_ext (bool, optional): Specifies whether the version is a SNOMED UK extension released after 2021. Defaults to False.
         uk_drug_ext (bool, optional): Specifies whether the version is a SNOMED UK drug extension. Defaults to False.
+        au_ext (bool, optional): Specifies wether the version is a AU release. Defaults to False.
     """
 
-    def __init__(self, data_path, uk_ext=False, uk_drug_ext=False):
+    def __init__(self, data_path, uk_ext=False, uk_drug_ext=False, au_ext: bool = False):
         self.data_path = data_path
         self.release = data_path[-16:-8]
         self.uk_ext = uk_ext
@@ -88,6 +89,11 @@ class Snomed:
             # NOTE for UK extensions starting from 20231122 the
             #      OPCS4 refset ID seems to be different
             self.opcs_refset_id = '1382401000000109'
+        self.au_ext = au_ext
+        # validate
+        if (self.uk_ext or self.uk_drug_ext) and self.au_ext:
+            raise ValueError("Cannot both be a UK and and a AU version. "
+                             f"Got UK={uk_ext}, UK_Drug={uk_drug_ext}, AU={au_ext}")
 
     def to_concept_df(self):
         """
@@ -107,6 +113,8 @@ class Snomed:
             contents_path = os.path.join(paths[i], "Snapshot", "Terminology")
             concept_snapshot = "sct2_Concept_Snapshot"
             description_snapshot = "sct2_Description_Snapshot-en"
+            if self.au_ext:
+                description_snapshot += "-AU"
             if self.uk_ext:
                 if "SnomedCT_UKClinicalRF2_PRODUCTION" in paths[i]:
                     concept_snapshot = "sct2_Concept_UKCLSnapshot"


### PR DESCRIPTION
This PR will make preprocessing work for the AU release if the folder structure is the same as it is for the UK and international releases:
`SnomedCT_{description}_{release}/Snapshot/Terminology/sct2_{files}.txt`
I.e a file like this exists:
`SnomedCT_Release_AU1000036_20240331T120000Z/Snapshot/Terminology/sct2_Description_Snapshot-en-AU_AU1000036_20240331.txt`

EDIT:
Just to clarify, in the example I've got, the relationship file (`sct2_Relationship_Snapshot_{SNOMED_VER}_{SNOMED_RELEASE}.txt`) does not seem to include the `-AU` part.