### PR TITLE
CU-8694dpy1c: Restrict mypy to below 1.10.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.6.0/en_core_web_md-3.6.0-py3-none-any.whl
 flake8~=7.0.0
 darglint~=1.8.1
-mypy>=1.7.0,<2.0.0
+mypy>=1.7.0,<1.10.0
 mypy-extensions>=1.0.0
 types-aiofiles==0.8.3
 types-PyYAML==6.0.3


### PR DESCRIPTION
`mypy` 1.10.0 was released yesterday.
Turns out it has a new feature where it doesn't work well with a few of our methods (`meta_cat.pipe` and ` transformers_ner.pipe`). 
The underlying reason is that the methods are supposed to be generators, but they have fallback returns as well.
This was fine in `mypy` 1.9.0 but now fails in 1.10.0.

So the easiest thing to do is to limit the `mypy` version.

I don't fully know why these fallbacks of returning the empty stream exist, so I'm hesitent in removing it.