### PR TITLE
CU-8694dpy1c: Return empty generator upon empty stream

### DIFF
--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -500,7 +500,6 @@ class MetaCAT(PipeRunner):
         # Just in case
         if stream is None or not stream:
             # return an empty generator
-            yield from ()
             return
 
         config = self.config

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -499,7 +499,8 @@ class MetaCAT(PipeRunner):
         """
         # Just in case
         if stream is None or not stream:
-            return stream
+            # return an empty generator
+            return iter(())
 
         config = self.config
         id2category_value = {v: k for k, v in config.general['category_value2id'].items()}

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -500,7 +500,8 @@ class MetaCAT(PipeRunner):
         # Just in case
         if stream is None or not stream:
             # return an empty generator
-            return iter(())
+            yield from ()
+            return
 
         config = self.config
         id2category_value = {v: k for k, v in config.general['category_value2id'].items()}

--- a/medcat/ner/transformers_ner.py
+++ b/medcat/ner/transformers_ner.py
@@ -362,7 +362,6 @@ class TransformersNER(object):
         # Just in case
         if stream is None or not stream:
             # return an empty generator
-            yield from ()
             return
 
         batch_size_chars = self.config.general['pipe_batch_size_in_chars']

--- a/medcat/ner/transformers_ner.py
+++ b/medcat/ner/transformers_ner.py
@@ -361,7 +361,8 @@ class TransformersNER(object):
         """
         # Just in case
         if stream is None or not stream:
-            return stream
+            # return an empty generator
+            return iter(())
 
         batch_size_chars = self.config.general['pipe_batch_size_in_chars']
         yield from self._process(stream, batch_size_chars)  # type: ignore

--- a/medcat/ner/transformers_ner.py
+++ b/medcat/ner/transformers_ner.py
@@ -362,7 +362,8 @@ class TransformersNER(object):
         # Just in case
         if stream is None or not stream:
             # return an empty generator
-            return iter(())
+            yield from ()
+            return
 
         batch_size_chars = self.config.general['pipe_batch_size_in_chars']
         yield from self._process(stream, batch_size_chars)  # type: ignore


### PR DESCRIPTION
Alternative to #422
Instead of restricting `mypy` version fixes the underlying issue. I.e returns empty generators where applicable.