### PR TITLE
CU-8694fae3r: Avoid publishing PyPI release when doing GH pre-releases

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ production, "v[0-9]+.[0-9]+.post" ]
   release:
-    types: [ published ]
+    types: [ published , edited ]
 
 jobs:
   build-n-publish-to-pypi:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -37,10 +37,6 @@ jobs:
           build
           --user
 
-      - name: Determine if it's a pre-release
-        id: check_prerelease
-        run: echo "IS_PRERELEASE=${{ github.event.release.prerelease }}" >> $GITHUB_ENV
-
       - name: Build a binary wheel and a source tarball
         run: >-
           python -m
@@ -51,9 +47,7 @@ jobs:
           .
 
       - name: Publish production distribution to PyPI
-        if: |
-          startsWith(github.ref, 'refs/tags') &&
-          ${{ env.IS_PRERELEASE != 'true' }}
+        if: startsWith(github.ref, 'refs/tags') && ! github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -37,6 +37,10 @@ jobs:
           build
           --user
 
+      - name: Determine if it's a pre-release
+        id: check_prerelease
+        run: echo "IS_PRERELEASE=${{ github.event.release.prerelease }}" >> $GITHUB_ENV
+
       - name: Build a binary wheel and a source tarball
         run: >-
           python -m
@@ -47,7 +51,9 @@ jobs:
           .
 
       - name: Publish production distribution to PyPI
-        if: startsWith(github.ref, 'refs/tags')
+        if: |
+          startsWith(github.ref, 'refs/tags') &&
+          ${{ env.IS_PRERELEASE != 'true' }}
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
What this PR does:
- During production workflow
  - Determines if a release is a pre-release on GitHub
  - If a release is a pre-release on GitHub, does not publish on PyPI

PS:
This is rather difficult to test since I cannot do the same in the main workflow because no release or pre-release is involved there.


The rationale:
If we want to do a Clinical Safety Review of a new release before publishing it on PyPI, we can draft a pre-release here on GitHub. Then we can process the review. And after that we can remove the pre-release tag and re-run the action to publish on PyPI.