### PR TITLE
CU-8694fk90t (almost) only primitive config

### DIFF
--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -18,7 +18,7 @@ from medcat.utils.saving.serializer import CDBSerializer
 from medcat.utils.config_utils import get_and_del_weighted_average_from_config
 from medcat.utils.config_utils import default_weighted_average
 from medcat.utils.config_utils import ensure_backward_compatibility
-from medcat.utils.config_utils import fix_waf_lambda
+from medcat.utils.config_utils import fix_waf_lambda, attempt_fix_weighted_average_function
 
 
 logger = logging.getLogger(__name__)
@@ -116,7 +116,7 @@ class CDB(object):
         if waf is not None:
             logger.info("Using (potentially) custom value of weighed "
                         "average function")
-            self.weighted_average_function = waf
+            self.weighted_average_function = attempt_fix_weighted_average_function(waf)
         elif hasattr(self, 'weighted_average_function'):
             # keep existing
             pass

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -631,5 +631,5 @@ def _wrapper(func, check_type: Type[FakeDict], advice: str):
 # wrap Linking.__getattribute__ so that when getting weighted_average_function
 # we get a nicer exceptio
 _waf_advice = "You can use `cat.cdb.weighted_average_function` to access it directly"
-Linking.__getattribute__ = _wrapper(Linking.__getattribute__, Linking, _waf_advice)
-Linking.__getitem__ = _wrapper(Linking.__getitem__, Linking, _waf_advice)
+Linking.__getattribute__ = _wrapper(Linking.__getattribute__, Linking, _waf_advice)  # type: ignore
+Linking.__getitem__ = _wrapper(Linking.__getitem__, Linking, _waf_advice)  # type: ignore

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -31,6 +31,7 @@ class FakeDict:
             raise KeyError from e
 
     def __setattr__(self, arg: str, val) -> None:
+        # TODO: remove this in the future when we stop stupporting this in config
         if isinstance(self, Linking) and arg == "weighted_average_function":
             val = attempt_fix_weighted_average_function(val)
         super().__setattr__(arg, val)
@@ -511,9 +512,6 @@ class Linking(MixingConfig, BaseModel):
     similarity calculation and will have a similarity of -1."""
     always_calculate_similarity: bool = False
     """Do we want to calculate context similarity even for concepts that are not ambigous."""
-    weighted_average_function: Callable[..., Any] = _DEFAULT_PARTIAL
-    """Weights for a weighted average
-    'weighted_average_function': partial(weighted_average, factor=0.02),"""
     calculate_dynamic_threshold: bool = False
     """Concepts below this similarity will be ignored. Type can be static/dynamic - if dynamic each CUI has a different TH
     and it is calcualted as the average confidence for that CUI * similarity_threshold. Take care that dynamic works only

--- a/medcat/linking/vector_context_model.py
+++ b/medcat/linking/vector_context_model.py
@@ -71,7 +71,7 @@ class ContextModel(object):
 
             values = []
             # Add left
-            values.extend([self.config.linking['weighted_average_function'](step) * self.vocab.vec(tkn.lower_)
+            values.extend([self.cdb.weighted_average_function(step) * self.vocab.vec(tkn.lower_)
                            for step, tkn in enumerate(tokens_left) if tkn.lower_ in self.vocab and self.vocab.vec(tkn.lower_) is not None])
 
             if not self.config.linking['context_ignore_center_tokens']:
@@ -83,7 +83,7 @@ class ContextModel(object):
                     values.extend([self.vocab.vec(tkn.lower_) for tkn in tokens_center if tkn.lower_ in self.vocab and self.vocab.vec(tkn.lower_) is not None])
 
             # Add right
-            values.extend([self.config.linking['weighted_average_function'](step) * self.vocab.vec(tkn.lower_)
+            values.extend([self.cdb.weighted_average_function(step) * self.vocab.vec(tkn.lower_)
                            for step, tkn in enumerate(tokens_right) if tkn.lower_ in self.vocab and self.vocab.vec(tkn.lower_) is not None])
 
             if len(values) > 0:

--- a/medcat/utils/config_utils.py
+++ b/medcat/utils/config_utils.py
@@ -1,20 +1,32 @@
 from functools import partial
-from typing import Callable
+from typing import Callable, Optional, Protocol
 import logging
 from pydantic import BaseModel
 
 
+class WAFCarrier(Protocol):
+
+    @property
+    def weighted_average_function(self) -> Callable[[float], int]:
+        pass
+
+
 logger = logging.getLogger(__name__)
+
+
+def fix_waf_lambda(carrier: WAFCarrier) -> None:
+    weighted_average_function = carrier.weighted_average_function  # type: ignore
+    if callable(weighted_average_function) and getattr(weighted_average_function, "__name__", None) == "<lambda>":
+        # the following type ignoring is for mypy because it is unable to detect the signature
+        carrier.weighted_average_function = partial(weighted_average, factor=0.0004) # type: ignore
 
 
 # NOTE: This method is a hacky workaround. The type ignores are because I cannot
 #       import config here since it would produce a circular import
 def ensure_backward_compatibility(config: BaseModel, workers: Callable[[], int]) -> None:
     # Hacky way of supporting old CDBs
-    weighted_average_function = config.linking.weighted_average_function  # type: ignore
-    if callable(weighted_average_function) and getattr(weighted_average_function, "__name__", None) == "<lambda>":
-        # the following type ignoring is for mypy because it is unable to detect the signature
-        config.linking.weighted_average_function = partial(weighted_average, factor=0.0004) # type: ignore
+    if hasattr(config.linking, 'weighted_average_function'):  # type: ignore
+        fix_waf_lambda(config.linking)  # type: ignore
     if config.general.workers is None:  # type: ignore
         config.general.workers = workers()  # type: ignore
     disabled_comps = config.general.spacy_disabled_components  # type: ignore
@@ -22,8 +34,23 @@ def ensure_backward_compatibility(config: BaseModel, workers: Callable[[], int])
         config.general.spacy_disabled_components.append('lemmatizer')  # type: ignore
 
 
+def get_and_del_weighted_average_from_config(config: BaseModel) -> Optional[Callable[[int], float]]:
+    if not hasattr(config, 'linking'):
+        return None
+    linking = config.linking
+    if not hasattr(linking, 'weighted_average_function'):
+        return None
+    waf = linking.weighted_average_function
+    delattr(linking, 'weighted_average_function')
+    return waf
+
+
 def weighted_average(step: int, factor: float) -> float:
     return max(0.1, 1 - (step ** 2 * factor))
+
+
+def default_weighted_average(step: int) -> float:
+    return weighted_average(step, factor=0.0004)
 
 
 def attempt_fix_weighted_average_function(waf: Callable[[int], float]

--- a/medcat/utils/config_utils.py
+++ b/medcat/utils/config_utils.py
@@ -14,6 +14,12 @@ class WAFCarrier(Protocol):
 logger = logging.getLogger(__name__)
 
 
+def is_old_type_config_dict(d: dict) -> bool:
+    if set(('py/object', 'py/state')) <= set(d.keys()):
+        return True
+    return False
+
+
 def fix_waf_lambda(carrier: WAFCarrier) -> None:
     weighted_average_function = carrier.weighted_average_function  # type: ignore
     if callable(weighted_average_function) and getattr(weighted_average_function, "__name__", None) == "<lambda>":

--- a/medcat/utils/saving/coding.py
+++ b/medcat/utils/saving/coding.py
@@ -1,6 +1,7 @@
 from typing import Any, Protocol, runtime_checkable, List, Union, Type, Optional, Callable
 
 import json
+import re
 
 
 @runtime_checkable
@@ -35,6 +36,7 @@ class PartEncoder(Protocol):
 
 
 SET_IDENTIFIER = '==SET=='
+PATTERN_IDENTIFIER = "==PATTERN=="
 
 
 class SetEncoder(PartEncoder):
@@ -79,10 +81,34 @@ class SetDecoder(PartDecoder):
         return dct
 
 
+class PatternEncoder(PartEncoder):
+
+    def try_encode(self, obj):
+        if isinstance(obj, re.Pattern):
+            return {PATTERN_IDENTIFIER: obj.pattern}
+        raise UnsuitableObject()
+
+
+class PatternDecoder(PartDecoder):
+
+    def try_decode(self, dct: dict) -> Union[dict, re.Pattern]:
+        """Decode re.Patttern from input dicts.
+
+        Args:
+            dct (dict): The input dict
+
+        Returns:
+            Union[dict, set]: The original dict if this was not a serialized pattern, the pattern otherwise
+        """
+        if PATTERN_IDENTIFIER in dct:
+            return re.compile(dct[PATTERN_IDENTIFIER])
+        return dct
+
+
 PostProcessor = Callable[[Any], None]  # CDB -> None
 
-DEFAULT_ENCODERS: List[Type[PartEncoder]] = [SetEncoder, ]
-DEFAULT_DECODERS: List[Type[PartDecoder]] = [SetDecoder, ]
+DEFAULT_ENCODERS: List[Type[PartEncoder]] = [SetEncoder, PatternEncoder]
+DEFAULT_DECODERS: List[Type[PartDecoder]] = [SetDecoder, PatternDecoder]
 LOADING_POSTPROCESSORS: List[PostProcessor] = []
 
 

--- a/medcat/utils/saving/coding.py
+++ b/medcat/utils/saving/coding.py
@@ -159,6 +159,8 @@ class CustomDelegatingDecoder(json.JSONDecoder):
     def def_inst(cls) -> 'CustomDelegatingDecoder':
         if cls._def_inst is None:
             cls._def_inst = cls([_cls() for _cls in DEFAULT_DECODERS])
+        elif len(cls._def_inst._delegates) < len(DEFAULT_DECODERS):
+            cls._def_inst = cls([_cls() for _cls in DEFAULT_DECODERS])
         return cls._def_inst
 
 

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -712,7 +712,7 @@ class TestLoadingOldWeights(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.cdb = CDB.load(cls.cdb_path)
-        cls.wf = cls.cdb.config.linking.weighted_average_function
+        cls.wf = cls.cdb.weighted_average_function
 
     def test_can_call_weights(self):
         res = self.wf(step=1)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ import unittest
 import pickle
 import tempfile
 from medcat.config import Config, MixingConfig, VersionInfo, General, LinkingFilters
+from medcat.config import UseOfOldConfigOptionException
 from pydantic import ValidationError
 import os
 
@@ -233,6 +234,20 @@ class ConfigLinkingFiltersTests(unittest.TestCase):
     def test_not_allow_empty_dict_for_cuis_exclude(self):
         with self.assertRaises(ValidationError):
             LinkingFilters(cuis_exclude={})
+
+
+class BackwardsCompatibilityTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.config = Config()
+
+    def test_use_weighted_average_function_identifier_nice_error(self):
+        with self.assertRaises(ValueError):
+            self.config.linking.weighted_average_function(0)
+
+    def test_use_weighted_average_function_dict_nice_error(self):
+        with self.assertRaises(UseOfOldConfigOptionException):
+            self.config.linking['weighted_average_function'](0)
 
 
 if __name__ == '__main__':

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ import unittest
 import pickle
 import tempfile
 from medcat.config import Config, MixingConfig, VersionInfo, General, LinkingFilters
-from medcat.config import UseOfOldConfigOptionException
+from medcat.config import UseOfOldConfigOptionException, Linking
 from pydantic import ValidationError
 import os
 
@@ -248,6 +248,23 @@ class BackwardsCompatibilityTests(unittest.TestCase):
     def test_use_weighted_average_function_dict_nice_error(self):
         with self.assertRaises(UseOfOldConfigOptionException):
             self.config.linking['weighted_average_function'](0)
+
+
+class BackwardsCompatibilityWafPayloadTests(unittest.TestCase):
+    arg = 'weighted_average_function'
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.config = Config()
+        with cls.assertRaises(cls, UseOfOldConfigOptionException) as cls.context:
+            cls.config.linking.weighted_average_function(0)
+        cls.raised = cls.context.exception
+
+    def test_exception_has_correct_conf_type(self):
+        self.assertIs(self.raised.conf_type, Linking)
+
+    def test_exception_has_correct_arg(self):
+        self.assertEqual(self.raised.arg_name, self.arg)
 
 
 if __name__ == '__main__':

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -208,6 +208,13 @@ class ConfigTests(unittest.TestCase):
         h2 = config.get_hash()
         self.assertEqual(h1, h2)
 
+    def test_can_save_load(self):
+        config = Config()
+        with tempfile.NamedTemporaryFile() as file:
+            config.save(file.name)
+            config2 = Config.load(file.name)
+        self.assertEqual(config, config2)
+
 
 class ConfigLinkingFiltersTests(unittest.TestCase):
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -242,7 +242,7 @@ class BackwardsCompatibilityTests(unittest.TestCase):
         self.config = Config()
 
     def test_use_weighted_average_function_identifier_nice_error(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(UseOfOldConfigOptionException):
             self.config.linking.weighted_average_function(0)
 
     def test_use_weighted_average_function_dict_nice_error(self):

--- a/tests/utils/saving/test_serialization.py
+++ b/tests/utils/saving/test_serialization.py
@@ -117,10 +117,6 @@ class ModelCreationTests(unittest.TestCase):
         # The spacy model has full path in the loaded model, thus won't be equal
         cat.config.general.spacy_model = os.path.basename(
             cat.config.general.spacy_model)
-        # There can also be issues with loading the config.linking.weighted_average_function from file
-        # This should be fixed with newer models,
-        # but the example model is older, so has the older functionalitys
-        cat.config.linking.weighted_average_function = self.undertest.config.linking.weighted_average_function
         self.assertEqual(cat.config.asdict(), self.undertest.config.asdict())
         self.assertEqual(cat.cdb.config, self.undertest.cdb.config)
         self.assertEqual(len(cat.vocab.vocab), len(self.undertest.vocab.vocab))

--- a/tests/utils/test_config_utils.py
+++ b/tests/utils/test_config_utils.py
@@ -1,0 +1,50 @@
+from medcat.config import Config
+from medcat.utils.saving.coding import default_hook, CustomDelegatingEncoder
+from medcat.utils import config_utils
+import json
+
+import unittest
+
+OLD_STYLE_DICT = {'py/object': 'medcat.config.VersionInfo',
+                  'py/state': {
+                      '__dict__': {
+                          'history': ['0c0de303b6dc0020',],
+                          'meta_cats': [],
+                          'cdb_info': {
+                              'Number of concepts': 785910,
+                              'Number of names': 2480049,
+                              'Number of concepts that received training': 378746,
+                              'Number of seen training examples in total': 1863973060,
+                              'Average training examples per concept': {
+                                  'py/reduce': [{'py/function': 'numpy.core.multiarray.scalar'},]
+                                  }
+                              },
+                          'performance': {'ner': {}, 'meta': {}},
+                          'description': 'No description',
+                          'id': 'ff4f4e00bc97de58',
+                          'last_modified': '26 April 2024',
+                          'location': None,
+                          'ontology': ['ONTOLOGY1'],
+                          'medcat_version': '1.10.2'
+                          },
+                      '__fields_set__': {
+                          'py/set': ['id', 'ontology', 'description', 'history',
+                                     'location', 'medcat_version', 'last_modified',
+                                     'meta_cats', 'cdb_info', 'performance']
+                                     },
+                      '__private_attribute_values__': {}
+                    }
+                 }
+
+
+NEW_STYLE_DICT = json.loads(json.dumps(Config().asdict(), cls=CustomDelegatingEncoder.def_inst),
+                            object_hook=default_hook)
+
+
+class ConfigUtilsTests(unittest.TestCase):
+
+    def test_identifies_old_style_dict(self):
+        self.assertTrue(config_utils.is_old_type_config_dict(OLD_STYLE_DICT))
+
+    def test_identifies_new_style_dict(self):
+        self.assertFalse(config_utils.is_old_type_config_dict(NEW_STYLE_DICT))


### PR DESCRIPTION
This PR removes `weighted_average_function` from the config and ties it to the `CDB` instead.

The idea is to be able to more simply save and load configs in a simpler json format.

So the PR also makes new saves of the config saved in (mostly) regular json.
There are a few caveats:
- Custom serialisation is used for `set`s and `re.Pattern`s
- And custom decoding as well
- So that means that a simple `json.load` will not create a useful dict to merge into a config

Some further things to note:
- The PR still allows loading old-style `jsonpickle`d configs
- Some things may have been moved around a little for simplicity
- This PR may complicate some things
  - There's a backwards compatibility method that already fixes `weighted_average_function` issues
    - I.e makes sure they're not `lambda`s
  - There's already python 3.11-specific fixers to `dill`'ed `weighted_average_function`s
    - I.e when the method was loaded but couldn't be used
  - If someone sets a different value for `cdb.weighted_average_function` multiprocessing may be problematic
    - I.e if a `lambda` is used this won't be `pickle`able  and multiprocessing methods will fail


Just to be clear, the previous json files were also human-readable. But they weren't as easy to follow as the (mostly) pure json that'd be used after this PR.
