### PR TITLE
CU-8694n48uw better deprecation

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -146,7 +146,8 @@ class CAT(object):
         # Set max document length
         self.pipe.spacy_nlp.max_length = config.preprocessing.max_document_length
 
-    @deprecated(message="Replaced with cat.pipe.spacy_nlp.")
+    @deprecated(message="Replaced with cat.pipe.spacy_nlp.",
+                depr_version=(1, 2, 7), removal_version=(1, 12, 0))
     def get_spacy_nlp(self) -> Language:
         """Returns the spacy pipeline with MedCAT
 
@@ -728,7 +729,8 @@ class CAT(object):
                     self.linker.context_model.train(cui=_cui, entity=spacy_entity, doc=spacy_doc, negative=True)  # type: ignore
 
     @deprecated(message="Use train_supervised_from_json to train based on data "
-                "loaded from a json file")
+                "loaded from a json file",
+                depr_version=(1, 8, 0), removal_version=(1, 12, 0))
     def train_supervised(self,
                          data_path: str,
                          reset_cui_count: bool = False,
@@ -1228,7 +1230,8 @@ class CAT(object):
             pickle.dump((annotated_ids, part_counter), open(annotated_ids_path, 'wb'))
         return part_counter
 
-    @deprecated(message="Use `multiprocessing_batch_char_size` instead")
+    @deprecated(message="Use `multiprocessing_batch_char_size` instead",
+                depr_version=(1, 10, 0), removal_version=(1, 12, 0))
     def multiprocessing(self,
                         data: Union[List[Tuple], Iterable[Tuple]],
                         nproc: int = 2,
@@ -1501,7 +1504,8 @@ class CAT(object):
 
         return docs
 
-    @deprecated(message="Use `multiprocessing_batch_docs_size` instead")
+    @deprecated(message="Use `multiprocessing_batch_docs_size` instead",
+                depr_version=(1, 10, 0), removal_version=(1, 12, 0))
     def multiprocessing_pipe(self, in_data: Union[List[Tuple], Iterable[Tuple]],
                              nproc: Optional[int] = None,
                              batch_size: Optional[int] = None,

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -247,7 +247,8 @@ class CDB(object):
 
         self._add_concept(cui=cui, names=names, ontologies=set(), name_status=name_status, type_ids=set(), description='', full_build=full_build)
 
-    @deprecated("Use `cdb._add_concept` as this will be removed in a future release.")
+    @deprecated("Use `cdb._add_concept` as this will be removed in a future release.",
+                depr_version=(1, 10, 0), removal_version=(1, 12, 0))
     def add_concept(self,
                     cui: str,
                     names: Dict[str, Dict],

--- a/medcat/meta_cat.py
+++ b/medcat/meta_cat.py
@@ -121,7 +121,8 @@ class MetaCAT(PipeRunner):
         hasher.update(self.config.get_hash())
         return hasher.hexdigest()
 
-    @deprecated(message="Use `train_from_json` or `train_raw` instead")
+    @deprecated(message="Use `train_from_json` or `train_raw` instead",
+                depr_version=(1, 8, 0), removal_version=(1, 12, 0))
     def train(self, json_path: Union[str, list], save_dir_path: Optional[str] = None, data_oversampled: Optional[list] = None) -> Dict:
         """Train or continue training a model give a json_path containing a MedCATtrainer export. It will
         continue training if an existing model is loaded or start new training if the model is blank/new.

--- a/medcat/utils/decorators.py
+++ b/medcat/utils/decorators.py
@@ -1,14 +1,30 @@
 import warnings
 import functools
-from typing import Callable
+from typing import Callable, Tuple
 
 
-def deprecated(message: str) -> Callable:
+def _format_version(ver: Tuple[int, int, int]) -> str:
+    return ".".join(str(v) for v in ver)
+
+
+def deprecated(message: str, depr_version: Tuple[int, int, int], removal_version: Tuple[int, int, int]) -> Callable:
+    """Deprecate a method.
+
+    Args:
+        message (str): The deprecation message.
+        depr_version (Tuple[int, int, int]): The first version of MedCAT where this was deprecated.
+        removal_version (Tuple[int, int, int]): The first version of MedCAT where this will be removed.
+
+    Returns:
+        Callable: _description_
+    """
     def decorator(func: Callable) -> Callable:
         @functools.wraps(func)
         def wrapped(*args, **kwargs) -> Callable:
             warnings.simplefilter("always", DeprecationWarning)
             warnings.warn("Function {} has been deprecated.{}".format(func.__name__, " " + message if message else ""))
+            warnings.warn(f"The above function was deprecated in v{_format_version(depr_version)} "
+                          f"and will be removed in v{removal_version}")
             warnings.simplefilter("default", DeprecationWarning)
             return func(*args, **kwargs)
         return wrapped

--- a/medcat/utils/ner/helpers.py
+++ b/medcat/utils/ner/helpers.py
@@ -47,7 +47,8 @@ def replace_entities_in_text(text: str,
 
 @deprecated("API now allows creating a DeId model (medcat.utils.ner.deid.DeIdModel). "
             "It aims to simplify the usage of DeId models. "
-            "The use of this model is encouraged over the use of this method.")
+            "The use of this model is encouraged over the use of this method.",
+            depr_version=(1, 8, 0), removal_version=(1, 12, 0))
 def deid_text(*args, **kwargs) -> str:
     return _deid_text(*args, **kwargs)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,25 @@
+from typing import Callable, Tuple
+
+from medcat.utils import decorators
+
+
+class DeprecatedMethodCallException(ValueError):
+
+    def __init__(self, func: Callable, msg: str,
+                 depr_version: Tuple[int, int, int],
+                 removal_version: Tuple[int, int, int]) -> None:
+        super().__init__(f"A deprecated method {func.__name__} was called. Deprecation message:\n{msg}\n"
+                         f"The method was deprecated in v{depr_version} and is scheduled for "
+                         f"removal in v{removal_version}")
+
+
+def deprecation_exception_raiser(message: str, depr_version: Tuple[int, int, int],
+                     removal_version: Tuple[int, int, int]):
+    def decorator(func: Callable) -> Callable:
+        def wrapper(*_, **__):
+            raise DeprecatedMethodCallException(func, message, depr_version, removal_version)
+        return wrapper
+    return decorator
+
+
+decorators.deprecated = deprecation_exception_raiser

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -301,9 +301,9 @@ class CATTests(unittest.TestCase):
         data_path = self.SUPERVISED_TRAINING_JSON
         ckpt_dir_path = temp_file
         checkpoint = Checkpoint(dir_path=ckpt_dir_path, steps=1, max_to_keep=sys.maxsize)
-        fp, fn, tp, p, r, f1, cui_counts, examples = self.undertest.train_supervised(data_path,
-                                                                                     checkpoint=checkpoint,
-                                                                                     nepochs=nepochs)
+        fp, fn, tp, p, r, f1, cui_counts, examples = self.undertest.train_supervised_from_json(data_path,
+                                                                                               checkpoint=checkpoint,
+                                                                                               nepochs=nepochs)
         checkpoints = [f for f in os.listdir(ckpt_dir_path) if "checkpoint-" in f]
         self.assertEqual({}, fp)
         self.assertEqual({}, fn)
@@ -328,13 +328,11 @@ class CATTests(unittest.TestCase):
         data_path = os.path.join(os.path.dirname(__file__), "resources", "medcat_trainer_export.json")
         ckpt_dir_path = temp_file
         checkpoint = Checkpoint(dir_path=ckpt_dir_path, steps=1, max_to_keep=sys.maxsize)
-        self.undertest.train_supervised(data_path,
-                                        checkpoint=checkpoint,
-                                        nepochs=nepochs_train)
-        fp, fn, tp, p, r, f1, cui_counts, examples = self.undertest.train_supervised(data_path,
-                                                                                     checkpoint=checkpoint,
-                                                                                     nepochs=nepochs_train+nepochs_retrain,
-                                                                                     is_resumed=True)
+        self.undertest.train_supervised_from_json(data_path,
+                                                  checkpoint=checkpoint,
+                                                  nepochs=nepochs_train)
+        fp, fn, tp, p, r, f1, cui_counts, examples = self.undertest.train_supervised_from_json(
+            data_path, checkpoint=checkpoint, nepochs=nepochs_train+nepochs_retrain, is_resumed=True)
         checkpoints = [f for f in os.listdir(ckpt_dir_path) if "checkpoint-" in f]
         self.assertEqual({}, fp)
         self.assertEqual({}, fn)
@@ -351,15 +349,15 @@ class CATTests(unittest.TestCase):
     def test_train_supervised_does_not_retain_MCT_filters_default(self, extra_cui_filter=None):
         data_path = os.path.join(os.path.dirname(__file__), "resources", "medcat_trainer_export_filtered.json")
         before = str(self.undertest.config.linking.filters)
-        self.undertest.train_supervised(data_path, nepochs=1, use_filters=True, extra_cui_filter=extra_cui_filter)
+        self.undertest.train_supervised_from_json(data_path, nepochs=1, use_filters=True, extra_cui_filter=extra_cui_filter)
         after = str(self.undertest.config.linking.filters)
         self.assertEqual(before, after)
 
     def test_train_supervised_can_retain_MCT_filters(self, extra_cui_filter=None, retain_extra_cui_filter=False):
         data_path = os.path.join(os.path.dirname(__file__), "resources", "medcat_trainer_export_filtered.json")
         before = str(self.undertest.config.linking.filters)
-        self.undertest.train_supervised(data_path, nepochs=1, use_filters=True, retain_filters=True,
-                                        extra_cui_filter=extra_cui_filter, retain_extra_cui_filter=retain_extra_cui_filter)
+        self.undertest.train_supervised_from_json(data_path, nepochs=1, use_filters=True, retain_filters=True,
+                                                  extra_cui_filter=extra_cui_filter, retain_extra_cui_filter=retain_extra_cui_filter)
         after = str(self.undertest.config.linking.filters)
         self.assertNotEqual(before, after)
         with open(data_path, 'r') as f:
@@ -701,7 +699,7 @@ def _get_meta_cat(meta_cat_dir):
                        config=config)
     os.makedirs(meta_cat_dir, exist_ok=True)
     json_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "resources", "mct_export_for_meta_cat_test.json")
-    meta_cat.train(json_path, save_dir_path=meta_cat_dir)
+    meta_cat.train_from_json(json_path, save_dir_path=meta_cat_dir)
     return meta_cat
 
 

--- a/tests/test_meta_cat.py
+++ b/tests/test_meta_cat.py
@@ -32,14 +32,14 @@ class MetaCATTests(unittest.TestCase):
     def test_train(self):
         json_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources',
                                  'mct_export_for_meta_cat_test.json')
-        results = self.meta_cat.train(json_path, save_dir_path=self.tmp_dir)
+        results = self.meta_cat.train_from_json(json_path, save_dir_path=self.tmp_dir)
         if self.meta_cat.config.model.phase_number != 1:
             self.assertEqual(results['report']['weighted avg']['f1-score'], 1.0)
 
     def test_save_load(self):
         json_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources',
                                  'mct_export_for_meta_cat_test.json')
-        self.meta_cat.train(json_path, save_dir_path=self.tmp_dir)
+        self.meta_cat.train_from_json(json_path, save_dir_path=self.tmp_dir)
         self.meta_cat.save(self.tmp_dir)
         n_meta_cat = MetaCAT.load(self.tmp_dir)
 
@@ -67,7 +67,7 @@ class MetaCATTests(unittest.TestCase):
     def test_predict_spangroup(self):
         json_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'resources',
                                  'mct_export_for_meta_cat_test.json')
-        self.meta_cat.train(json_path, save_dir_path=self.tmp_dir)
+        self.meta_cat.train_from_json(json_path, save_dir_path=self.tmp_dir)
         self.meta_cat.save(self.tmp_dir)
         n_meta_cat = MetaCAT.load(self.tmp_dir)
 


### PR DESCRIPTION
We've got a few deprecated methods in MedCAT. But there isn't much documentation as to when they might get removed.

There also isn't anything that would check for the usage of deprecated methods in the codebase.

So what this PR does is improve the situation by:
- Adding deprecation and removal version arguments to the deprecation decorator
  - Along with filling in the details for existing methods
- Makes deprecated methods raise an exception during test time
  - So that we (hopefully) avoid using them in our test suite and/or codebase
- Fixes uses of deprecated methods in the tests