### PR TITLE
CU-8694p8y0k deprecation GHA check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           VERSION: ${{ steps.get_latest_release.outputs.latest_version }}
         run: |
-          python tests/check_deprecations.py "$VERSION" --next-version
+          python tests/check_deprecations.py "$VERSION" --next-version --remove-prefix
 
   publish-to-test-pypi:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const latestRelease = await github.repos.getLatestRelease({
+            const latestRelease = await github.rest.repos.getLatestRelease({
               owner: context.repo.owner,
               repo: context.repo.repo
             });

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,8 @@ jobs:
             core.setOutput('latest_version', latestRelease.data.tag_name);
 
       - name: Make sure there's no deprecated methods that should be removed.
+        # only run this for master -> production PR. I.e just before doing a release.
+        if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'production'
         env:
           VERSION: ${{ steps.get_latest_release.outputs.latest_version }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,23 @@ jobs:
         run: |
           timeout 17m python -m unittest discover
 
+      - name: Get the latest release version
+        id: get_latest_release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const latestRelease = await github.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            core.setOutput('latest_version', latestRelease.data.tag_name);
+
+      - name: Make sure there's no deprecated methods that should be removed.
+        env:
+          VERSION: ${{ steps.get_latest_release.outputs.latest_version }}
+        run: |
+          python tests/check_deprecations.py "$VERSION" --next-version
+
   publish-to-test-pypi:
 
     if: |

--- a/tests/check_deprecations.py
+++ b/tests/check_deprecations.py
@@ -128,6 +128,11 @@ def get_deprecated_methods_that_should_have_been_removed(codebase_path: str,
     return should_be_removed
 
 
+def _ver2str(ver: Tuple[int, int, int]) -> str:
+    maj, min, patch = ver
+    return f"v{maj}.{min}.{patch}"
+
+
 def main(args: List[str] = sys_argv[1:],
          deprecated_decorator: Callable[[], Callable] = deprecated):
     decorator_name = deprecated_decorator.__name__
@@ -158,11 +163,12 @@ def main(args: List[str] = sys_argv[1:],
 
     to_remove = get_deprecated_methods_that_should_have_been_removed(codebase_path, decorator_name, medcat_version)
 
+    ver_descr = "next" if compare_next_minor_release else "current"
     for filepath, func_name, rem_ver in to_remove:
         print("SHOULD ALREADY BE REMOVED")
         print(f"In file: {filepath}")
         print(f" Method: {func_name}")
-        print(f" Scheduled for removal in: {rem_ver}")
+        print(f" Scheduled for removal in: {_ver2str(rem_ver)} ({ver_descr} version: {_ver2str(medcat_version)})")
     if to_remove:
         print("Found issues - see above")
         sys_exit(1)

--- a/tests/check_deprecations.py
+++ b/tests/check_deprecations.py
@@ -1,0 +1,166 @@
+from typing import List, Dict, Optional, Tuple, Callable
+import ast
+import os
+from sys import argv as sys_argv
+from sys import exit as sys_exit
+from medcat.utils.decorators import deprecated
+
+
+def get_decorator_args(decorator: ast.expr, decorator_name: str) -> Tuple[Optional[List[str]], Optional[Dict[str, str]]]:
+    if isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Name) and decorator.func.id == decorator_name:
+        return decorator.args, {kw.arg: kw.value for kw in decorator.keywords}
+    return None, None
+
+
+def is_decorated_with(node: ast.FunctionDef, decorator_name: str) -> Tuple[bool, List[str], Dict[str, str]]:
+    for decorator in node.decorator_list:
+        if isinstance(decorator, ast.Name) and decorator.id == decorator_name:
+            return True, [], {}
+        elif isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Name) and decorator.func.id == decorator_name:
+            args, kwargs = get_decorator_args(decorator, decorator_name)
+            return True, args, kwargs
+    return False, [], {}
+
+
+class FunctionVisitor(ast.NodeVisitor):
+    def __init__(self, decorator_name: str):
+        self.decorator_name = decorator_name
+        self.decorated_functions: List[Dict[str, Optional[List[str]]]] = []
+        self.context: List[str] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self.context.append(node.name)
+        is_decorated, args, kwargs = is_decorated_with(node, self.decorator_name)
+        if is_decorated:
+            self.decorated_functions.append({
+                'name': '.'.join(self.context),
+                'args': args,
+                'kwargs': kwargs
+            })
+        self.generic_visit(node)
+        self.context.pop()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self.visit_FunctionDef(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.context.append(node.name)
+        self.generic_visit(node)
+        self.context.pop()
+
+
+def find_decorated_functions_in_file(filepath: str, decorator_name: str) -> List[Dict[str, Optional[List[str]]]]:
+    with open(filepath, "r") as source:
+        tree = ast.parse(source.read())
+
+    visitor = FunctionVisitor(decorator_name)
+    visitor.visit(tree)
+    return visitor.decorated_functions
+
+
+def find_decorated_functions_in_codebase(codebase_path: str, decorator_name: str) -> Dict[str, List[Dict[str, Optional[List[str]]]]]:
+    decorated_functions: Dict[str, List[Dict[str, Optional[List[str]]]]] = {}
+    for root, _, files in os.walk(codebase_path):
+        for file in files:
+            if file.endswith(".py"):
+                filepath = os.path.join(root, file)
+                decorated_funcs = find_decorated_functions_in_file(filepath, decorator_name)
+                if decorated_funcs:
+                    decorated_functions[filepath] = decorated_funcs
+    return decorated_functions
+
+
+def extract_version_from_tuple(tuple_node: ast.Tuple) -> Tuple[int, int, int]:
+    """Extract constant values from an ast.Tuple node.
+
+    Args:
+        tuple_node (ast.Tuple): The AST node representing the tuple.
+
+    Raises:
+        ValueError: If the tuple contains unsuitable values.
+
+    Returns:
+        Tuple[int, int, int]: The major, minor, and patch version.
+    """
+    values = []
+    for element in tuple_node.elts:
+        if isinstance(element, ast.Constant):
+            cur_value = element.value
+        else:
+            raise ValueError(f"Unsupported element type in tuple: {type(element)}")
+        values.append(cur_value)
+        if not isinstance(cur_value, int):
+            raise ValueError(f"Unknown type of value in version tuple: {type(cur_value)}: {cur_value}")
+    if len(values) != 3:
+        raise ValueError(f"Unexpected number of version elements ({len(values)}): {values}")
+    return tuple(values)
+
+
+def get_deprecated_methods_that_should_have_been_removed(codebase_path: str,
+                                                         decorator_name: str,
+                                                         medcat_version: Tuple[int, int, int]
+                                                         ) -> List[Tuple[str, str, Tuple[int, int, int]]]:
+    """Get deprecated methods that should have been removed.
+
+    Args:
+        codebase_path (str): Path to codebase.
+        decorator_name (str): Name of decorator to check.
+        medcat_version (Tuple[int, int, int]): The current MedCAT version.
+
+    Returns:
+        List[Tuple[str, str, Tuple[int, int, int]]]:
+            The list of file, method, and version in which the method should have been deprecated.
+    """
+    decorated_functions = find_decorated_functions_in_codebase(codebase_path, decorator_name)
+
+    should_be_removed = []
+    for filepath, funcs in decorated_functions.items():
+        for func in funcs:
+            func_name = func['name']
+            args, kwargs = func['args'], func['kwargs']
+            if 'removal_version' in kwargs:
+                rem_ver = kwargs['removal_version']
+            else:
+                rem_ver = args[-1]
+            rem_ver = extract_version_from_tuple(rem_ver)
+            if rem_ver <= medcat_version:
+                should_be_removed.append((filepath, func_name, rem_ver))
+    return should_be_removed
+
+
+def main(args: List[str] = sys_argv[1:],
+         deprecated_decorator: Callable[[], Callable] = deprecated):
+    decorator_name = deprecated_decorator.__name__
+    pos_args = [arg for arg in args if not arg.startswith("-")]
+    codebase_path = 'medcat' if len(pos_args) <= 1 else pos_args[1]
+    medcat_version = tuple(int(s) for s in args[0].split("."))
+    compare_next_minor_release = '--next-version' in args
+
+    # pad out medcat varesions
+    # NOTE: Mostly so that e.g (1, 12, 0) <= (1, 12, 0) would be True.
+    #       Otherwise (1, 12, 0) <= (1, 12) would equate to False.
+    if len(medcat_version) < 3:
+        medcat_version = tuple(list(medcat_version) + [0,] * (3 - len(medcat_version)))
+    # NOTE: In main GHA workflow we know the current minor release
+    #       but after that release has been done, we (generally, but not always!)
+    #       want to start removing deprecated methods due to be removed before
+    #       the next minor release.
+    if compare_next_minor_release:
+        l_ver = list(medcat_version)
+        l_ver[1] += 1
+        medcat_version = tuple(l_ver)
+
+    to_remove = get_deprecated_methods_that_should_have_been_removed(codebase_path, decorator_name, medcat_version)
+
+    for filepath, func_name, rem_ver in to_remove:
+        print("SHOULD ALREADY BE REMOVED")
+        print(f"In file: {filepath}")
+        print(f" Method: {func_name}")
+        print(f" Scheduled for removal in: {rem_ver}")
+    if to_remove:
+        print("Found issues - see above")
+        sys_exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/check_deprecations.py
+++ b/tests/check_deprecations.py
@@ -133,7 +133,13 @@ def main(args: List[str] = sys_argv[1:],
     decorator_name = deprecated_decorator.__name__
     pos_args = [arg for arg in args if not arg.startswith("-")]
     codebase_path = 'medcat' if len(pos_args) <= 1 else pos_args[1]
-    medcat_version = tuple(int(s) for s in args[0].split("."))
+    print("arg0", repr(args[0]))
+    remove_ver_prefix = '--remove-prefix' in args
+    pure_ver = pos_args[0]
+    if remove_ver_prefix:
+        # remove v from (e.g) v1.12.0
+        pure_ver = pure_ver[1:]
+    medcat_version = tuple(int(s) for s in pure_ver.split("."))
     compare_next_minor_release = '--next-version' in args
 
     # pad out medcat varesions


### PR DESCRIPTION
Make sure deprecated methods are removed before next release.

What this PR does:
- Adds a small bit of code that
  - Finds all deprecated methods
  - Checks if each deprecated method is already supposed to have been removed
- Adds these checks to the main GitHub Actions workflow
  - But only runs right before a release, for `master` -> `production` PR

How it determines what's "supposed to be removed":
- It determines the latest release on GitHub within GitHub Actions
- It then increments the minor version (`<major>.<minor>.<patch>`)
- If the `removal_version` argument of a deprecated method is higher than or equal to the upcoming (minor) release, this method is deemed to need removal

Some caveats:
- This relies on the assumption of the next release version being the next minor version
  - Otherwise we'd already be too late when checking
  - I.e the version where something was supposed to be removed has already been released
- This would result in issues with patch releases
  - If there's a PR to fix something for a patch release where the next major release would warrant the removal of a deprecated method, the main workflow will fail upon `master` -> `production` PR before release
  - Which would sort of force the removal of such deprecated methods before the noted version
- ~~When doing post-releases (i.e patch releases for older minor/major versions)~~
  - ~~Similar issue as before~~ (now resolved, see EDIT)

How I made sure this does what I expect it to do:
- I ran some tests on a PR on a fork
- I changed a deprecated method's version to a lower one
- Made sure the workflow ran as expected and successfully
  - Had to add a latest 'release' to the fork
- And the workflow failed as expected
  - With some details, see [here](https://github.com/mart-r/MedCAT/actions/runs/9287525792/job/25556779567?pr=34).
- EDIT
  - Turns out I showed it more specifically in this PR as well
  - Because I hadn't foreseen an issue with existing deprecated methods which are to be removed next minor release

~~I think we could add an `if` statement to the step to not run it on post-releases. But this may sort of mean that patch releases (even for the latest version) would need to always be done on `v1.x-post` branches.
But regardless, I've put it up here for now for potential discussion. Don't want to spend time on bits that may not be relevant, after all.~~

EDIT:
I've made the deprecation check only run if the PR is from `master` into `production`. As such, this should now only run just before a regular release. Though this would still be problematic before patch releases on the current version.