### PR TITLE
CU-8694u3yd2 cleanup name removal

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -691,7 +691,7 @@ class CAT(object):
 
         # Remove name from all CUIs
         for c in cuis:
-            self.cdb.remove_names(cui=c, names=names)
+            self.cdb.remove_names(cui=c, names=names.keys())
 
     def add_and_train_concept(self,
                               cui: str,

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -682,7 +682,10 @@ class CAT(object):
             names = prepare_name(name, self.pipe.spacy_nlp, {}, self.config)
 
         # If full unlink find all CUIs
-        if self.config.general.get('full_unlink', False):
+        if self.config.general.full_unlink:
+            logger.warning("In the config `full_unlink` is set to `True`. "
+                           "Thus removing all CUIs linked to the specified name"
+                           " (%s)", name)
             for n in names:
                 cuis.extend(self.cdb.name2cuis.get(n, []))
 

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -691,7 +691,7 @@ class CAT(object):
 
         # Remove name from all CUIs
         for c in cuis:
-            self.cdb.remove_names(cui=c, names=names.keys())
+            self.cdb._remove_names(cui=c, names=names.keys())
 
     def add_and_train_concept(self,
                               cui: str,

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -148,6 +148,11 @@ class CDB(object):
                                             (self.cui2count_train.get(cui, 0) + 1)
         self.is_dirty = True
 
+    @deprecated("Deprecated. For internal use only. Use CAT.unlink_concept_name instead",
+                depr_version=(1, 12, 0), removal_version=(1, 13, 0))
+    def remove_names(self, cui: str, names: Iterable[str]) -> None:
+        self._remove_names(cui, names)
+
     def _remove_names(self, cui: str, names: Iterable[str]) -> None:
         """Remove names from an existing concept - effect is this name will never again be used to link to this concept.
         This will only remove the name from the linker (namely name2cuis and name2cuis2status), the name will still be present everywhere else.

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -148,7 +148,7 @@ class CDB(object):
                                             (self.cui2count_train.get(cui, 0) + 1)
         self.is_dirty = True
 
-    def remove_names(self, cui: str, names: Iterable[str]) -> None:
+    def _remove_names(self, cui: str, names: Iterable[str]) -> None:
         """Remove names from an existing concept - effect is this name will never again be used to link to this concept.
         This will only remove the name from the linker (namely name2cuis and name2cuis2status), the name will still be present everywhere else.
         Why? Because it is bothersome to remove it from everywhere, but

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -158,7 +158,7 @@ class CDB(object):
             cui (str):
                 Concept ID or unique identifer in this database.
             names (Iterable[str]):
-                Names to be removed (e.g list).
+                Names to be removed (e.g list, set, or even a dict (in which case keys will be used)).
         """
         for name in names:
             if name in self.name2cuis:

--- a/medcat/cdb.py
+++ b/medcat/cdb.py
@@ -5,7 +5,7 @@ import json
 import logging
 import aiofiles
 import numpy as np
-from typing import Dict, Set, Optional, List, Union, cast
+from typing import Dict, Set, Optional, List, Union, cast, Iterable
 import os
 
 from medcat import __version__
@@ -148,7 +148,7 @@ class CDB(object):
                                             (self.cui2count_train.get(cui, 0) + 1)
         self.is_dirty = True
 
-    def remove_names(self, cui: str, names: Dict[str, Dict]) -> None:
+    def remove_names(self, cui: str, names: Iterable[str]) -> None:
         """Remove names from an existing concept - effect is this name will never again be used to link to this concept.
         This will only remove the name from the linker (namely name2cuis and name2cuis2status), the name will still be present everywhere else.
         Why? Because it is bothersome to remove it from everywhere, but
@@ -157,10 +157,10 @@ class CDB(object):
         Args:
             cui (str):
                 Concept ID or unique identifer in this database.
-            names (Dict[str, Dict]):
-                Names to be removed, should look like: `{'name': {'tokens': tokens, 'snames': snames, 'raw_name': raw_name}, ...}`
+            names (Iterable[str]):
+                Names to be removed (e.g list).
         """
-        for name in names.keys():
+        for name in names:
             if name in self.name2cuis:
                 if cui in self.name2cuis[name]:
                     self.name2cuis[name].remove(cui)

--- a/tests/test_cdb_maker.py
+++ b/tests/test_cdb_maker.py
@@ -132,6 +132,24 @@ class B_CDBMakerEditTests(unittest.TestCase):
     def tearDownClass(cls) -> None:
         cls.maker.destroy_pipe()
 
+    # NOTE: The following tests are state-dependent. That is to say,
+    #       if the order in which they're executed changes, they may fail.
+    #       They currently rely on the fact that test methods are executed
+    #       in anlphabetic order. But this is overall not good test design
+    #       since failure of one unit could lead to the failure of another
+    #       in unsexpected ways (since there's an expectation on the state).
+    #
+    #       e.g, if I run:
+    #           python -m unittest\
+    #               tests.test_cdb_maker.B_CDBMakerEditTests.test_bd_addition_of_context_vector_positive\
+    #               tests.test_cdb_maker.B_CDBMakerEditTests.test_bc_filter_by_cui\
+    #               tests.test_cdb_maker.B_CDBMakerEditTests.test_bb_removal_of_name\
+    #               tests.test_cdb_maker.B_CDBMakerEditTests.test_ba_addition_of_new_name
+    #       Then there will be failures in `test_ba_addition_of_new_name` and `test_bb_removal_of_name`
+    #       due to the changes in state.
+    #
+    #       Though to make it clear, in the standard configuration the tests run in the
+    #       "correct" order and are successful.
     def test_ba_addition_of_new_name(self):
         self.cdb.add_names(cui='C0000239', names=prepare_name('MY: new,-_! Name.', self.maker.pipe.spacy_nlp, {}, self.config), name_status='P', full_build=True)
         self.assertEqual(len(self.cdb.name2cuis), 6, "Should equal 6")

--- a/tests/test_cdb_maker.py
+++ b/tests/test_cdb_maker.py
@@ -160,7 +160,7 @@ class B_CDBMakerEditTests(unittest.TestCase):
         self.assertIn('my~:~new~name~.', self.cdb.name2cuis2status)
 
     def test_bb_removal_of_name(self):
-        self.cdb.remove_names(cui='C0000239', names=prepare_name('MY: new,-_! Name.', self.maker.pipe.spacy_nlp, {}, self.config))
+        self.cdb._remove_names(cui='C0000239', names=prepare_name('MY: new,-_! Name.', self.maker.pipe.spacy_nlp, {}, self.config))
         self.assertEqual(len(self.cdb.name2cuis), 5, "Should equal 5")
         self.assertNotIn('my:newname.', self.cdb.name2cuis2status)
 


### PR DESCRIPTION
Name removal may be a little confusing. There's a `CDB.remove_names` method, but it seems to require a `Dict[str, Dict]` whereas in reality it only just iterates over the keys of this `dict`.

Realistically, users should probably usually use `CAT.unlink_concept_name` instead.

With that said, what this PR does:
- Protects (prepends with `_`) the `CDB.remove_names` (so now `CDB._remove_names`)
- Keeps a deprecated `CDB.remove_names` method due for removal in medcat v`1.13`
- Add a log message to `CAT.unlink_concept_name` when doing a full-unlink (as per config)
- Makes `CDB._remove_names` accept and use `Iterable[str]` instead of `Dict[str, Dict]`

NOTE:
While looking at some of the tests that used `CDB.remove_names`, I saw that some of the tests (probably more than I actually noted down) are state and order dependent. And while the default implementation does run them in the correct order (alphabetic test method order), this is not an ideal situation. Because the tests depend on the class state failure of one could force a (seemingly) unrelated failure of another. Even removal or change of one test could result in failure of other(s). Ideally, the CDB state would be reset between each test (so state saved at `setUp` and restored at `tearDown`). Code to do this exists in PR #432 but has not yet been merged.