### PR TITLE
CU-8694vcvz7: Trust remote code when loading transfomers NER dataset

### DIFF
--- a/medcat/ner/transformers_ner.py
+++ b/medcat/ner/transformers_ner.py
@@ -181,7 +181,8 @@ class TransformersNER(object):
             dataset = datasets.load_dataset(os.path.abspath(transformers_ner.__file__),
                                             data_files={'train': json_path}, # type: ignore
                                             split='train',
-                                            cache_dir='/tmp/')
+                                            cache_dir='/tmp/',
+                                            trust_remote_code=True)
             # We split before encoding so the split is document level, as encoding
             #does the document spliting into max_seq_len
             dataset = dataset.train_test_split(test_size=self.config.general['test_size']) # type: ignore

--- a/medcat/ner/transformers_ner.py
+++ b/medcat/ner/transformers_ner.py
@@ -4,8 +4,10 @@ import logging
 import datasets
 from spacy.tokens import Doc
 from datetime import datetime
-from typing import Iterable, Iterator, Optional, Dict, List, cast, Union, Tuple
+from typing import Iterable, Iterator, Optional, Dict, List, cast, Union, Tuple, Callable
 from spacy.tokens import Span
+import inspect
+from functools import partial
 
 from medcat.cdb import CDB
 from medcat.utils.meta_cat.ml_utils import set_all_seeds
@@ -178,11 +180,21 @@ class TransformersNER(object):
             json_path = self._prepare_dataset(json_path, ignore_extra_labels=ignore_extra_labels,
                                               meta_requirements=meta_requirements, file_name='data_eval.json')
             # Load dataset
-            dataset = datasets.load_dataset(os.path.abspath(transformers_ner.__file__),
-                                            data_files={'train': json_path}, # type: ignore
-                                            split='train',
-                                            cache_dir='/tmp/',
-                                            trust_remote_code=True)
+
+            # NOTE: The following is for backwards comppatibility
+            #       in datasets==2.20.0 `trust_remote_code=True` must be explicitly
+            #       specified, otherwise an error is raised.
+            #       On the other hand, the keyword argumnet was added in datasets==2.16.0
+            #       yet we support datasets>=2.2.0.
+            #       So we need to use the kwarg if applicable and omit its use otherwise.
+            if func_has_kwarg(datasets.load_dataset, 'trust_remote_code'):
+                ds_load_dataset = partial(datasets.load_dataset, trust_remote_code=True)
+            else:
+                ds_load_dataset = datasets.load_dataset
+            dataset = ds_load_dataset(os.path.abspath(transformers_ner.__file__),
+                                      data_files={'train': json_path}, # type: ignore
+                                      split='train',
+                                      cache_dir='/tmp/')
             # We split before encoding so the split is document level, as encoding
             #does the document spliting into max_seq_len
             dataset = dataset.train_test_split(test_size=self.config.general['test_size']) # type: ignore
@@ -423,3 +435,9 @@ class TransformersNER(object):
         doc = next(self.pipe(iter([doc])))
 
         return doc
+
+
+# NOTE: Only needed for datasets backwards compatibility
+def func_has_kwarg(func: Callable, keyword: str):
+    sig = inspect.signature(func)
+    return keyword in sig.parameters


### PR DESCRIPTION
3rd of June when merging 
https://github.com/CogStack/MedCAT/pull/449
We had the following dependencies installed on GHA:
https://gist.github.com/mart-r/fbcaf2efd797a61b610148dc2772ac36
And the actions ran successfully:
https://github.com/CogStack/MedCAT/actions/runs/9347830207/job/25725635617
(the log will be erased at some later date - I think it was 90 days)

On 17th and 18th of June, when trying to merge
https://github.com/CogStack/MedCAT/pull/438
We had the following dependencies installed:
https://gist.github.com/mart-r/0581771a9db05d5b33e6eff4e6f05a60
And the GHA FAILED:
https://github.com/CogStack/MedCAT/actions/runs/9550033321/job/26321052562?pr=438
With failed tests (in case this is not showing)
https://gist.github.com/mart-r/6bbbd7225d0cc52446bf2ab75fa675b0


The differences in the dependencies between the two runs:
   - accelerate 0.30.1 -> 0.31.0
   - datasets 2.19.2 -> 2.20.0
   - filelock 3.14.0 -> 3.15.1
   - fsspec 2024.3.1 -> 2024.5.0
   - huggingface-hub 0.23.2 -> 0.23.4
   - jsonpickle 3.0.4 -> 3.2.1
   - Marisa-trie 1.1.1 -> 1.2.0
   - packaging 24.0 -> 24.1
   - prompt-toolkit 3.0.45 -> 3.0.47
   - pydantic 1.10.15 -> 1.10.16
   - torch 2.3.0 -> 2.3.1
   - triton 2.3.0 -> 2.3.1
   - typing-extensions 4.12.1 -> 4.12.2
   - urllib3 2.2.1 -> 2.2.2
 
However, due to the nature of the errors in the failure(s), I'm fairly certain the issue is with `datasets` bump. The weird thing is though that when I installed the same version locally (tried both in an existing and a brand new environment) the same error was not present. Not entirely sure why.

In any case, this PR tells `datasets` to trust the "remote" code executed ran when loading the Transformers NER dataset.

EDIT:
There's an issue with this!
The added argument (`trust_remote_code`) was added in `datasets==2.16.0`, but we support `'datasets>=2.2.2,<3.0.0'`.
So this PR needs to be amended to either:
- Bump the datasets dependency to minimum `2.16.0`
- Remove the change and cap the max datasets dependency to `<2.20.0`
- Add a version check and support both with and without this argument