### PR TITLE
CU-8694wh3d5 track usage

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -504,7 +504,12 @@ class CAT(object):
                 # NOTE: pipe returns Doc (not List[Doc]) since we passed str (not List[str])
                 #       that's why we ignore type here
                 #       But it could still be None if the text is empty
-                nents = 0 if rval is None else len(rval.ents)  # type: ignore
+                if rval is None:
+                    nents = 0
+                elif self.config.general.show_nested_entities:
+                    nents = len(rval._.ents)  # type: ignore
+                else:
+                    nents = len(rval.ents)  # type: ignore
                 self.usage_monitor.log_inference(l1, l2, nents)
                 return rval  # type: ignore
             else:

--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -41,6 +41,7 @@ from medcat.utils.saving.serializer import SPECIALITY_NAMES, ONE2MANY
 from medcat.utils.saving.envsnapshot import get_environment_info, ENV_SNAPSHOT_FILE_NAME
 from medcat.stats.stats import get_stats
 from medcat.utils.filters import set_project_filters
+from medcat.utils.usage_monitoring import UsageMonitor
 
 
 logger = logging.getLogger(__name__) # separate logger from the package-level one
@@ -108,6 +109,7 @@ class CAT(object):
         self._rel_cats = rel_cats
         self._addl_ner = addl_ner if isinstance(addl_ner, list) else [addl_ner]
         self._create_pipeline(self.config)
+        self.usage_monitor = UsageMonitor(self.get_hash(), self.config.general.usage_monitor)
 
     def _create_pipeline(self, config: Config):
         # Set log level
@@ -493,8 +495,21 @@ class CAT(object):
             logger.error("The input text should be either a string or a sequence of strings but got %s", type(text))
             return None
         else:
-            text = self._get_trimmed_text(str(text))
-            return self.pipe(text)  # type: ignore
+            text = str(text)  # NOTE: shouldn't be necessary but left it in
+            if self.config.general.usage_monitor.enabled:
+                l1 = len(text)
+                text = self._get_trimmed_text(text)
+                l2 = len(text)
+                rval = self.pipe(text)
+                # NOTE: pipe returns Doc (not List[Doc]) since we passed str (not List[str])
+                #       that's why we ignore type here
+                #       But it could still be None if the text is empty
+                nents = 0 if rval is None else len(rval.ents)  # type: ignore
+                self.usage_monitor.log_inference(l1, l2, nents)
+                return rval  # type: ignore
+            else:
+                text = self._get_trimmed_text(text)
+                return self.pipe(text)  # type: ignore
 
     def __repr__(self) -> str:
         """Prints the model_card for this CAT instance.

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -321,12 +321,25 @@ class CheckPoint(MixingConfig, BaseModel):
         validate_assignment = True
 
 
+class UsageMonitor(MixingConfig, BaseModel):
+    enabled: bool = True
+    """Whether usage monitoring is enabled."""
+    batch_size: int = 10
+    """Number of logged events to write at once."""
+    file_prefix: str = "usage_"
+    """The prefix for logged files. The suffix will be the model hash."""
+    log_folder: str = "."
+    """The folder which contains the usage logs. In certain situations,
+    it may make sense to keep this separate from the overall logs."""
+
+
 class General(MixingConfig, BaseModel):
     """The general part of the config"""
     spacy_disabled_components: list = ['ner', 'parser', 'vectors', 'textcat',
                                        'entity_linker', 'sentencizer', 'entity_ruler', 'merge_noun_chunks',
                                        'merge_entities', 'merge_subtokens']
     checkpoint: CheckPoint = CheckPoint()
+    usage_monitor = UsageMonitor()
     """Checkpointing config"""
     log_level: int = logging.INFO
     """Logging config for everything | 'tagger' can be disabled, but will cause a drop in performance"""

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -327,8 +327,10 @@ class UsageMonitor(MixingConfig, BaseModel):
 
     If set to False, no logging is performed.
     If set to True, logs are saved in the location specified by `log_folder`.
-    If set to 'auto', logs will be automatically distributed according to the
-    OS preferred logs location. That is:
+    If set to 'auto', logs will be automatically enabled or disabled based on
+    environmenta variable (`MEDCAT_LOGS` - setting it to False or 0 disabled logging)
+    and distributed according to the OS preferred logs location (`MEDCAT_LOGS_LOCATION`).
+    The defaults for the location are:
      - For Linux: ~/.local/share/medcat/logs/
      - For Windows: C:\Users\%USERNAME%\.cache\medcat\logs\
     """

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from pydantic import BaseModel, Extra, ValidationError
 from pydantic.fields import ModelField
-from typing import List, Set, Tuple, cast, Any, Callable, Dict, Optional, Union, Type
+from typing import List, Set, Tuple, cast, Any, Callable, Dict, Optional, Union, Type, Literal
 from multiprocessing import cpu_count
 import logging
 import jsonpickle
@@ -322,15 +322,25 @@ class CheckPoint(MixingConfig, BaseModel):
 
 
 class UsageMonitor(MixingConfig, BaseModel):
-    enabled: bool = False
-    """Whether usage monitoring is enabled."""
-    batch_size: int = 10
+    enabled: Literal[True, False, 'auto'] = False
+    r"""Whether usage monitoring is enabled (True), disabled (False), or automatic ('auto').
+
+    If set to False, no logging is performed.
+    If set to True, logs are saved in the location specified by `log_folder`.
+    If set to 'auto', logs will be automatically distributed according to the
+    OS preferred logs location. That is:
+     - For Linux: ~/.local/share/medcat/logs/
+     - For Windows: C:\Users\%USERNAME%\.cache\medcat\logs\
+    """
+    batch_size: int = 100
     """Number of logged events to write at once."""
     file_prefix: str = "usage_"
     """The prefix for logged files. The suffix will be the model hash."""
     log_folder: str = "."
     """The folder which contains the usage logs. In certain situations,
-    it may make sense to keep this separate from the overall logs."""
+    it may make sense to keep this separate from the overall logs.
+
+    NOTE: Does not take affect if `enabled` is set to 'auto'"""
 
 
 class General(MixingConfig, BaseModel):

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -322,7 +322,7 @@ class CheckPoint(MixingConfig, BaseModel):
 
 
 class UsageMonitor(MixingConfig, BaseModel):
-    enabled: bool = True
+    enabled: bool = False
     """Whether usage monitoring is enabled."""
     batch_size: int = 10
     """Number of logged events to write at once."""

--- a/medcat/utils/usage_monitoring.py
+++ b/medcat/utils/usage_monitoring.py
@@ -1,0 +1,43 @@
+import os
+from datetime import datetime
+from typing import List
+
+from medcat.config import UsageMonitor as UsageMonitorConfig
+
+
+class UsageMonitor:
+
+    def __init__(self, model_hash: str, config: UsageMonitorConfig) -> None:
+        self.config = config
+        self.log_buffer: List[str] = []
+        # NOTE: if the model hash changes (i.e model is trained)
+        #       then this does not immediately take effect
+        self.model_hash = model_hash
+
+    @property
+    def log_file(self):
+        return os.path.join(
+            self.config.log_folder,
+            f"{self.config.file_prefix}{self.model_hash}.csv")
+
+    def log_inference(self,
+                      input_text_len: int,
+                      trimmed_text_len: int,
+                      nr_of_ents_found: int) -> None:
+        timestamp = datetime.now().isoformat()
+        log_entry = f"{timestamp},{input_text_len},{trimmed_text_len},{nr_of_ents_found}"
+        self.log_buffer.append(log_entry)
+        if len(self.log_buffer) >= self.config.batch_size:
+            self._flush_logs()
+
+    def _flush_logs(self) -> None:
+        if not self.log_buffer:
+            return
+        with open(self.log_file, 'a') as f:
+            for log_entry in self.log_buffer:
+                f.write(log_entry + '\n')
+        self.log_buffer = []
+
+    def __del__(self):
+        # fail safe for when buffer is non-empty upon application stop (i.e exit call)
+        self._flush_logs()

--- a/medcat/utils/usage_monitoring.py
+++ b/medcat/utils/usage_monitoring.py
@@ -1,8 +1,21 @@
 import os
 from datetime import datetime
 from typing import List
+import platform
+import logging
 
 from medcat.config import UsageMonitor as UsageMonitorConfig
+
+
+LOGS_ENV = "MEDCAT_LOGS"
+LOGS_LOC_ENV = "MEDCAT_LOGS_LOCATION"
+
+DEFAULT_LOGS_WINDOWS = os.path.join(os.environ.get('APPDATA', "NOT WINDOWS"), 'medcat', 'logs')
+DEFAULT_LOGS_LINUX = os.path.expanduser("~/.local/share/medcat/logs/")
+DEFAULT_LOGS_MACOS = os.path.expanduser("~/Library/Application Support/medcat/logs/")
+
+
+logger = logging.getLogger(__name__)
 
 
 class UsageMonitor:
@@ -20,10 +33,55 @@ class UsageMonitor:
             self.config.log_folder,
             f"{self.config.file_prefix}{self.model_hash}.csv")
 
+    def _get_auto_logs_location(self):
+        system = platform.system().lower()
+        if system == "windows":
+            return DEFAULT_LOGS_WINDOWS
+        elif system == "linux":
+            return DEFAULT_LOGS_LINUX
+        elif system == "darwin":  # macOS
+            return DEFAULT_LOGS_MACOS
+        else:
+            raise OSError(f"Unsupported operating system: {system}")
+
+    def _setup_auto_logs(self):
+        # NOTE: os.environ is a snapshot of the environmental variables
+        #       from the time that the process was started.
+        #       However, someone could still change os.environm manually
+        log_dir = os.environ.get(LOGS_LOC_ENV, self._get_auto_logs_location())
+        if not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+        if log_dir != self.config.log_folder:
+            self.config.log_folder = log_dir
+
+    def _should_log(self) -> bool:
+        if not self.config.enabled:
+            logger.warning("Trying to log to file when the usage monitor is "
+                           "disabled. This should generally not happen unless "
+                           "the config kept track of by the CAT object has is "
+                           "different from the one kept track of by the usage "
+                           "monitor. So if this keeps coming up, make sure "
+                           "everything is up to date")
+            return False
+        elif self.config.enabled is True:
+            return True
+        elif self.config.enabled != 'auto':
+            raise ValueError("Unknown UsageMonitor enabled status: "
+                             f"{self.config.enabled}. Expected one of: "
+                             f"True, False, 'auto'")
+        # enabled == 'auto'
+        env_enabled = os.environ.get(LOGS_ENV, "false").lower()
+        if env_enabled in ("false", "0"):
+            return False
+        self._setup_auto_logs()
+        return True
+
     def log_inference(self,
                       input_text_len: int,
                       trimmed_text_len: int,
                       nr_of_ents_found: int) -> None:
+        if not self._should_log():
+            return
         timestamp = datetime.now().isoformat()
         log_entry = f"{timestamp},{input_text_len},{trimmed_text_len},{nr_of_ents_found}"
         self.log_buffer.append(log_entry)

--- a/medcat/utils/usage_monitoring.py
+++ b/medcat/utils/usage_monitoring.py
@@ -7,8 +7,8 @@ import logging
 from medcat.config import UsageMonitor as UsageMonitorConfig
 
 
-LOGS_ENV = "MEDCAT_LOGS"
-LOGS_LOC_ENV = "MEDCAT_LOGS_LOCATION"
+LOGS_ENV = "MEDCAT_USAGE_LOGS"
+LOGS_LOC_ENV = "MEDCAT_USAGE_LOGS_LOCATION"
 
 DEFAULT_LOGS_WINDOWS = os.path.join(os.environ.get('APPDATA', "NOT WINDOWS"), 'medcat', 'logs')
 DEFAULT_LOGS_LINUX = os.path.expanduser("~/.local/share/medcat/logs/")

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -592,6 +592,18 @@ class CATTests(unittest.TestCase):
             contents = f.readline()
         self.assertTrue(contents)
 
+    def test_get_entities_logs_usage(self,
+                                     text="The dog is sitting outside the house."):
+        # clear usage monitor buffer
+        self.undertest.usage_monitor.log_buffer.clear()
+        self.undertest.get_entities(text)
+        self.assertTrue(self.undertest.usage_monitor.log_buffer)
+        self.assertEqual(len(self.undertest.usage_monitor.log_buffer), 1)
+        line = self.undertest.usage_monitor.log_buffer[0]
+        # the 1st element is the input text length
+        input_text_length = line.split(",")[1]
+        self.assertEqual(str(len(text)), input_text_length)
+
 
 class GetEntitiesWithStopWords(unittest.TestCase):
     # NB! The order in which the different CDBs are created

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -37,6 +37,7 @@ class CATTests(unittest.TestCase):
         cls.cdb.config.linking.disamb_length_limit = 5
         cls.cdb.config.general.full_unlink = True
         cls._temp_logs_folder = tempfile.TemporaryDirectory()
+        cls.cdb.config.general.usage_monitor.enabled = True
         cls.cdb.config.general.usage_monitor.log_folder = cls._temp_logs_folder.name
         cls.meta_cat_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp")
         cls.undertest = CAT(cdb=cls.cdb, config=cls.cdb.config, vocab=cls.vocab, meta_cats=[])

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -36,6 +36,8 @@ class CATTests(unittest.TestCase):
         cls.cdb.config.linking.train = True
         cls.cdb.config.linking.disamb_length_limit = 5
         cls.cdb.config.general.full_unlink = True
+        cls._temp_logs_folder = tempfile.TemporaryDirectory()
+        cls.cdb.config.general.usage_monitor.log_folder = cls._temp_logs_folder.name
         cls.meta_cat_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "tmp")
         cls.undertest = CAT(cdb=cls.cdb, config=cls.cdb.config, vocab=cls.vocab, meta_cats=[])
         cls._linkng_filters = cls.undertest.config.linking.filters.copy_of()
@@ -45,6 +47,7 @@ class CATTests(unittest.TestCase):
         cls.undertest.destroy_pipe()
         if os.path.exists(cls.meta_cat_dir):
             shutil.rmtree(cls.meta_cat_dir)
+        cls._temp_logs_folder.cleanup()
 
     def setUp(self):
         self._temp_file = tempfile.NamedTemporaryFile()
@@ -54,6 +57,10 @@ class CATTests(unittest.TestCase):
         # need to make sure linking filters are not retained beyond a test scope
         self.undertest.config.linking.filters = self._linkng_filters.copy_of()
         self._temp_file.close()
+        # remove existing contents / empty file log file
+        log_file_path = self.undertest.usage_monitor.log_file
+        if os.path.exists(log_file_path):
+            os.remove(log_file_path)
 
     def test_callable_with_single_text(self):
         text = "The dog is sitting outside the house."
@@ -572,6 +579,18 @@ class CATTests(unittest.TestCase):
     def test_add_and_train_concept_cdb_warns_short_name(self):
         short_name = 'a'
         self.assertLogsDuringAddAndTrainConcept(cdb_logger, logging.WARNING, name=short_name, name_status='P', nr_of_calls=1)
+
+    def test_get_entities_gets_monitored(self,
+                                         text="Some text"):
+        repeats = self.undertest.config.general.usage_monitor.batch_size
+        # ensure something gets written to the file
+        for _ in range(repeats):
+            self.undertest.get_entities(text)
+        log_file_path = self.undertest.usage_monitor.log_file
+        self.assertTrue(os.path.exists(log_file_path))
+        with open(log_file_path) as f:
+            contents = f.readline()
+        self.assertTrue(contents)
 
 
 class GetEntitiesWithStopWords(unittest.TestCase):

--- a/tests/utils/test_usage_monitoring.py
+++ b/tests/utils/test_usage_monitoring.py
@@ -1,0 +1,88 @@
+import os
+
+from medcat.config import UsageMonitor as UsageMonitorConfig
+from medcat.utils import usage_monitoring
+
+import tempfile
+
+from unittest import TestCase
+
+
+class UsageMonitorBaseTests(TestCase):
+    MODEL_HASH = "MODEL_HASH"
+    BATCH_SIZE = 10
+    ALL_DATA = [
+        (10, 10, 2), (100, 90, 4), (110, 110, 0)
+    ]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.config = UsageMonitorConfig(enabled=True,
+                                        batch_size=cls.BATCH_SIZE)
+
+    def setUp(self) -> None:
+        self._temp_dir = tempfile.TemporaryDirectory()
+        self.config.log_folder = self._temp_dir.name
+        self.monitor = usage_monitoring.UsageMonitor(self.MODEL_HASH,
+                                                     self.config)
+        for data in self.ALL_DATA:
+            self.monitor.log_inference(*data)
+
+    def _get_saved_lines(self) -> list:
+        if not os.path.exists(self.monitor.log_file):
+            return []
+        with open(self.monitor.log_file) as f:
+            return f.readlines()
+
+    def tearDown(self) -> None:
+        self.monitor.log_buffer.clear()
+        self._temp_dir.cleanup()
+
+
+class UsageMonitorInBufferTests(UsageMonitorBaseTests):
+    BATCH_SIZE = 100
+
+    def test_nothing_in_file(self):
+        self.assertFalse(self._get_saved_lines())
+
+    def test_all_in_buffer(self):
+        lines = self.monitor.log_buffer
+        self.assertEqual(len(lines), len(self.ALL_DATA))
+        for data_nr, (data, line) in enumerate(zip(self.ALL_DATA, lines)):
+            for sub_nr, nr in enumerate(data):
+                with self.subTest(f"{data_nr}-{sub_nr} ({nr})"):
+                    self.assertIn(str(nr), line)
+
+
+class UsageMonitorInFileTests(UsageMonitorBaseTests):
+    BATCH_SIZE = 1
+
+    def test_nothing_in_buffer(self):
+        self.assertFalse(self.monitor.log_buffer)
+
+    def test_all_in_file(self):
+        lines = self._get_saved_lines()
+        self.assertEqual(len(lines), len(self.ALL_DATA))
+        for data_nr, (data, line) in enumerate(zip(self.ALL_DATA, lines)):
+            for sub_nr, nr in enumerate(data):
+                with self.subTest(f"{data_nr}-{sub_nr} ({nr})"):
+                    self.assertIn(str(nr), line)
+
+
+class InterMediateUsageMonitorTests(UsageMonitorBaseTests):
+    BATCH_SIZE = 2
+
+    def setUp(self) -> None:
+        super().setUp()
+        total_items = len(self.ALL_DATA)
+        self.expected_in_buffer = total_items % self.BATCH_SIZE
+        self.expected_in_file = total_items - self.expected_in_buffer
+
+    def test_some_in_buffer(self):
+        self.assertTrue(self.monitor.log_buffer)
+        self.assertEqual(len(self.monitor.log_buffer), self.expected_in_buffer)
+
+    def test_some_in_file(self):
+        lines = self._get_saved_lines()
+        self.assertTrue(lines)
+        self.assertEqual(len(lines), self.expected_in_file)

--- a/tests/utils/test_usage_monitoring.py
+++ b/tests/utils/test_usage_monitoring.py
@@ -91,16 +91,16 @@ class InterMediateUsageMonitorTests(UsageMonitorBaseTests):
 
 class UMT(UsageMonitorBaseTests):
     ENABLED_DICT = {
-        "MEDCAT_LOGS": "True",
-        "MEDCAT_LOGS_LOCATION": "."
+        "MEDCAT_USAGE_LOGS": "True",
+        "MEDCAT_USAGE_LOGS_LOCATION": "."
     }
     DISABLED_DICT_1 = {
-        "MEDCAT_LOGS": "False",
-        "MEDCAT_LOGS_LOCATION": "FAIL" # should not change anything
+        "MEDCAT_USAGE_LOGS": "False",
+        "MEDCAT_USAGE_LOGS_LOCATION": "FAIL" # should not change anything
     }
     DISABLED_DICT_2 = {
-        "MEDCAT_LOGS": "0",
-        "MEDCAT_LOGS_LOCATION": "."
+        "MEDCAT_USAGE_LOGS": "0",
+        "MEDCAT_USAGE_LOGS_LOCATION": "."
     }
 
     def setUp(self) -> None:
@@ -114,7 +114,7 @@ class UMT(UsageMonitorBaseTests):
     def test_listens_to_os_environ_enabled(self):
         self.assertTrue(self.monitor._should_log())
         self.assertNotEqual(self.config.log_folder, self._temp_dir.name)
-        self.assertEqual(self.config.log_folder, self.ENABLED_DICT["MEDCAT_LOGS_LOCATION"])
+        self.assertEqual(self.config.log_folder, self.ENABLED_DICT["MEDCAT_USAGE_LOGS_LOCATION"])
 
     @patch.dict(os.environ, DISABLED_DICT_1)
     def test_listens_to_os_environ_disabled_1(self):


### PR DESCRIPTION
Add a usage monitor.

What it does is monitor:
- The input text length
- The input preprocessed text length
- The number of output entities

The usage monitor is configured such that it logs on file every time 10 (configurable) inferences are logged (to avoid constant IO). It also logs the rest of the buffer when the user monitor is dereferenced.

This PR also adds the relevant config part (`config.general.usage_monitor`). The usage monitoring can be disabled if needed by changing the config.