### PR TITLE
CU-86951923u: Add option for simplified hash along with a few tests

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -158,6 +158,10 @@ class CAT(object):
             str: The resulting hash
         """
         hasher = Hasher()
+        if self.config.general.simple_hash:
+            logger.info("Using simplified hashing that only takes into account the model card")
+            hasher.update(self.get_model_card())
+            return hasher.hexdigest()
         hasher.update(self.cdb.get_hash(force_recalc))
 
         hasher.update(self.config.get_hash())

--- a/medcat/config.py
+++ b/medcat/config.py
@@ -360,6 +360,11 @@ class General(MixingConfig, BaseModel):
     if `long` it will be CUI | Name | Confidence"""
     map_cui_to_group: bool = False
     """If the cdb.addl_info['cui2group'] is provided and this option enabled, each CUI will be maped to the group"""
+    simple_hash: bool = False
+    """Whether to use a simple hash.
+
+    NOTE: While using a simple hash is faster at save time, it is less
+    reliable due to not taking into account all the details of the changes."""
 
     class Config:
         extra = Extra.allow

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -1,7 +1,9 @@
 import json
 import os
 import sys
+import time
 import unittest
+from unittest.mock import mock_open, patch
 import tempfile
 import shutil
 import logging
@@ -48,6 +50,7 @@ class CATTests(unittest.TestCase):
 
     def setUp(self):
         self._temp_file = tempfile.NamedTemporaryFile()
+        self.cdb.config.general.simple_hash = False
 
     def tearDown(self) -> None:
         self.cdb.config.annotation_output.include_text_in_output = False
@@ -572,6 +575,41 @@ class CATTests(unittest.TestCase):
     def test_add_and_train_concept_cdb_warns_short_name(self):
         short_name = 'a'
         self.assertLogsDuringAddAndTrainConcept(cdb_logger, logging.WARNING, name=short_name, name_status='P', nr_of_calls=1)
+
+    def test_simple_hashing_is_faster(self):
+        st = time.perf_counter()
+        self.undertest.get_hash(force_recalc=True)
+        took_normal = time.perf_counter() - st
+        self.undertest.config.general.simple_hash = True  # will be reset at setUp
+        st = time.perf_counter()
+        self.undertest.get_hash(force_recalc=True)
+        took_simple = time.perf_counter() - st
+        # NOTE: In reality simple has should take less than 5 ms
+        self.assertLess(took_simple, took_normal)
+
+    def perform_fake_save(self, fake_folder: str = "FAKE_FOLDER"):
+        with (patch('os.makedirs'),
+                patch('os.path.join', return_value=f"{fake_folder}/data.dat"),
+                patch('builtins.open', mock_open()),
+                patch('shutil.copytree'),
+                patch('shutil.make_archive'),
+                # to fix envsnapshot
+                patch('platform.platform', return_value='TEST')):
+            self.undertest.create_model_pack(fake_folder)
+
+    def test_subsequent_simple_hashes_same(self):
+        self.undertest.config.general.simple_hash = True  # will be reset at setUp
+        hash1 = self.undertest.get_hash(force_recalc=True)
+        hash2 = self.undertest.get_hash(force_recalc=True)
+        self.assertEqual(hash1, hash2)
+
+    def test_simple_hashing_changes_after_save(self):
+        self.undertest.config.general.simple_hash = True  # will be reset at setUp
+        hash1 = self.undertest.get_hash(force_recalc=True)
+        # simulating save
+        self.perform_fake_save()
+        hash2 = self.undertest.get_hash(force_recalc=True)
+        self.assertNotEqual(hash1, hash2)
 
 
 class GetEntitiesWithStopWords(unittest.TestCase):


### PR DESCRIPTION
Add option for simplified hash for the model pack. This simplified hash only hashes the model card. This means it the hash has to change every time the model pack is saved since the previous hash is added to the config history and (subsequently) model card upon each save.

The new config option is at:
```
config.general.simple_hash
```

The idea is to improve the save times. However, this simplified hash is a little less reliable since it will change every time the model is saved, regardless of whether or not the CDB itself was changed (i.e regardless of whether or not any fine tuning was done).



