### PR TITLE
CU-8694vv985 transitive deps

### DIFF
--- a/medcat/utils/saving/envsnapshot.py
+++ b/medcat/utils/saving/envsnapshot.py
@@ -4,6 +4,10 @@ import os
 import re
 import pkg_resources
 import platform
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 ENV_SNAPSHOT_FILE_NAME = "environment_snapshot.json"
@@ -42,6 +46,47 @@ def get_direct_dependencies() -> Set[str]:
     return set(re.split("[@<=>~]", dep)[0].strip() for dep in deps)
 
 
+def _update_installed_dependencies_recursive(
+        gathered: Dict[str, str],
+        package: pkg_resources.Distribution) -> Dict[str, str]:
+    if package.project_name in gathered:
+        logger.debug("Trying to update already found transitive dependency '%'",
+                     package.egg_name)
+        return gathered
+    for req in package.requires():
+        if req.project_name in gathered:
+            logger.debug("Trying to look up already found transitive dependency '%'",
+                         req.project_name)
+            continue # don't look for it again
+        try:
+            dep = pkg_resources.get_distribution(req.project_name)
+        except pkg_resources.DistributionNotFound as e:
+            logger.warning("Unable to locate requirement '%s':", req.project_name,
+                           exc_info=e)
+            continue
+        gathered[dep.project_name] = dep.version
+        _update_installed_dependencies_recursive(gathered, dep)
+    return gathered
+
+
+def get_transitive_deps(direct_deps: List[str]) -> List[List[str]]:
+    """Get the transitive dependencies of the direct dependencies.
+
+    Args:
+        direct_deps (List[str]): List of direct dependencies.
+
+    Returns:
+        List[List[str]]: The list of dependency names along with their versions.
+    """
+    # map from name to version so as to avoid multiples of the same package
+    all_transitive_deps: Dict[str, str] = {}
+    for dep in direct_deps:
+        package = pkg_resources.get_distribution(dep)
+        _update_installed_dependencies_recursive(all_transitive_deps, package)
+    trans_deps = [list(td) for td in all_transitive_deps.items()]
+    return sorted(trans_deps, key=lambda t: t[0])
+
+
 def get_installed_packages() -> List[List[str]]:
     """Get the installed packages and their versions.
 
@@ -57,17 +102,24 @@ def get_installed_packages() -> List[List[str]]:
     return installed_packages
 
 
-def get_environment_info() -> Dict[str, Any]:
+def get_environment_info(include_transitive_deps: bool = True) -> Dict[str, Any]:
     """Get the current environment information.
+
+    Args:
+        include_transitive_deps (bool): Whether to include transitive dependencies. Defaults to True.
 
     This includes dependency versions, the OS, the CPU architecture and the python version.
 
     Returns:
         Dict[str, Any]: _description_
     """
-    return {
+    env_info = {
         "dependencies": get_installed_packages(),
         "os": platform.platform(),
         "cpu_architecture": platform.machine(),
         "python_version": platform.python_version()
     }
+    if include_transitive_deps:
+        direct_deps = [dep_name for dep_name, _ in env_info["dependencies"]]
+        env_info["transitive_deps"] = get_transitive_deps(direct_deps)
+    return env_info

--- a/tests/utils/saving/test_envsnapshot.py
+++ b/tests/utils/saving/test_envsnapshot.py
@@ -103,3 +103,33 @@ class EnvSnapshotInCATTests(unittest.TestCase):
     def test_zip_has_env_snapshot(self):
         filenames = list_zip_contents(self.cat_folder + ".zip")
         self.assertIn(ENV_SNAPSHOT_FILE_NAME, filenames)
+
+
+class EnvSnapshotTranistiveDepsTests(unittest.TestCase):
+    TRANSITIVE_KEY = "transitive_deps"
+    env_no_transitive = envsnapshot.get_environment_info(
+        include_transitive_deps=False)
+    env_w_transitive = envsnapshot.get_environment_info(
+        include_transitive_deps=True)
+
+    def test_can_exclude_transitive(self):
+        self.assertNotIn(self.TRANSITIVE_KEY, self.env_no_transitive)
+
+    def test_can_have_transitive(self):
+        self.assertIn(self.TRANSITIVE_KEY, self.env_w_transitive)
+
+    @property
+    def transitive_deps(self):
+        return self.env_w_transitive[self.TRANSITIVE_KEY]
+
+    def test_can_find_transitive(self):
+        self.assertTrue(self.transitive_deps) # more than one
+        self.assertIsInstance(self.transitive_deps, list)
+
+    def test_trans_deps_have_name_and_versions(self):
+        for i, td in enumerate(self.transitive_deps):
+            with self.subTest(f"Transitive dependency - {i}"):
+                self.assertIsInstance(td, list)
+                self.assertEqual(len(td), 2)
+                self.assertIsInstance(td[0], str)
+                self.assertIsInstance(td[1], str)


### PR DESCRIPTION
Add all transitive dependencies to the environmental snapshot.

We added transitive dependencies to MedCAT in v1.12 (#438). However, that only included direct dependencies of MedCAT.
In principle, the compatible versions of transitive dependencies should be handled by the package that defines them. However, these things can change over time and there may be a situation where the requirements ranges previously set no longer work properly. As such, by including all the transitive dependencies (and their versions) in the environmental snapshot could help us recreate an environment where we'd expect a model to work more confidently.


There's a few decisions I made that _could_ very well be open to change:
1. Currently, the transitive dependencies are in a separate part of the json
 - I thought it would be good to explicitly separate them from direct dependencies
 - Though if there's good reasons to keep all dependencies together, it could be changed
2. Currently, the default behaviour includes transitive dependencies
 - It shouldn't be too computationally expensive
 - But if there's a good reason, we can have it disabled by default

The change to the default environmental snapshot as a result of the PR is as follows:
- Previously:
```json
{
  "dependencies": [
    ["aiofiles", "23.2.1"], ["humanfriendly", "10.0"], ["click", "8.1.7"],
    ["ipywidgets", "8.1.2"], ["psutil", "5.9.8"], ["tqdm", "4.66.4"],
    ["transformers", "4.40.2"], ["gensim", "4.3.2"], ["spacy", "3.6.1"],
    ["xxhash", "3.4.1"], ["jsonpickle", "3.0.3"], ["datasets", "2.20.0"],
    ["torch", "2.2.1"], ["pandas", "2.2.1"], ["numpy", "1.25.2"],
    ["pydantic", "1.10.14"], ["scipy", "1.9.3"], ["scikit-learn", "1.4.1.post1"],
    ["multiprocess", "0.70.16"], ["accelerate", "0.30.1"], ["peft", "0.11.0"],
    ["blis", "0.7.11"], ["dill", "0.3.8"]
  ],
  "os": "macOS-14.5-arm64-arm-64bit",
  "cpu_architecture": "arm64",
  "python_version": "3.10.13"
}
```
- Now:
```json
{
  "dependencies": [
    ["aiofiles", "23.2.1"], ["humanfriendly", "10.0"], ["click", "8.1.7"],
    ["ipywidgets", "8.1.2"], ["psutil", "5.9.8"], ["tqdm", "4.66.4"],
    ["transformers", "4.40.2"], ["gensim", "4.3.2"], ["spacy", "3.6.1"],
    ["xxhash", "3.4.1"], ["jsonpickle", "3.0.3"], ["datasets", "2.20.0"],
    ["torch", "2.2.1"], ["pandas", "2.2.1"], ["numpy", "1.25.2"],
    ["pydantic", "1.10.14"], ["scipy", "1.9.3"], ["scikit-learn", "1.4.1.post1"],
    ["multiprocess", "0.70.16"], ["accelerate", "0.30.1"], ["peft", "0.11.0"],
    ["blis", "0.7.11"], ["dill", "0.3.8"]
  ],
  "os": "macOS-14.5-arm64-arm-64bit",
  "cpu_architecture": "arm64",
  "python_version": "3.10.13",
  "transitive_deps": [
    ["PyYAML", "6.0.1"], ["accelerate", "0.30.1"], ["aiohttp", "3.9.3"],
    ["catalogue", "2.0.10"], ["comm", "0.2.1"], ["cymem", "2.0.8"],
    ["dill", "0.3.8"], ["filelock", "3.13.1"], ["fsspec", "2023.10.0"],
    ["huggingface-hub", "0.23.0"], ["ipython", "8.22.1"],
    ["jinja2", "3.1.4"], ["joblib", "1.3.2"], ["jupyterlab-widgets", "3.0.10"],
    ["langcodes", "3.3.0"], ["multiprocess", "0.70.16"], ["murmurhash", "1.0.10"],
    ["networkx", "3.2.1"], ["numpy", "1.25.2"], ["packaging", "23.2"],
    ["pandas", "2.2.1"], ["pathy", "0.11.0"], ["preshed", "3.0.9"],
    ["psutil", "5.9.8"], ["pyarrow", "15.0.0"], ["pyarrow-hotfix", "0.6"],
    ["pydantic", "1.10.14"], ["regex", "2024.5.10"], ["requests", "2.32.3"],
    ["safetensors", "0.4.2"], ["scipy", "1.9.3"], ["setuptools", "65.5.0"],
    ["smart-open", "6.4.0"], ["spacy-legacy", "3.0.12"], ["spacy-loggers", "1.0.5"],
    ["srsly", "2.4.8"], ["sympy", "1.12"], ["thinc", "8.1.12"],
    ["threadpoolctl", "3.3.0"], ["tokenizers", "0.19.1"], ["torch", "2.2.1"],
    ["tqdm", "4.66.4"], ["traitlets", "5.14.1"], ["transformers", "4.40.2"],
    ["typer", "0.9.0"], ["typing-extensions", "4.10.0"], ["wasabi", "1.1.2"],
    ["widgetsnbextension", "4.0.10"], ["xxhash", "3.4.1"]
  ]
}
```
NOTE: The default JSON format would be different (more concise) in either case.