### PR TITLE
CU-869588fdc: Comment on blis 1.0.0 (to show GHA failure)

### DIFF
--- a/install_requires.txt
+++ b/install_requires.txt
@@ -17,7 +17,7 @@
 'aiofiles>=0.8.0' # allow later versions, tested with 22.1.0
 'ipywidgets>=7.6.5' # allow later versions, tested with 0.8.0
 'xxhash>=3.0.0' # allow later versions, tested with 3.1.0
-'blis>=0.7.5' # allow later versions, tested with 0.7.9, avoid 1.0.0 (depends on numpy 2)
+'blis>=0.7.5,<1.0.0' # allow later versions, tested with 0.7.9, avoid 1.0.0 (depends on numpy 2)
 'click>=8.0.4' # allow later versions, tested with 8.1.3
 'pydantic>=1.10.0,<2.0' # for spacy compatibility; avoid 2.0 due to breaking changes
 "humanfriendly~=10.0"  # for human readable file / RAM sizes

--- a/install_requires.txt
+++ b/install_requires.txt
@@ -17,7 +17,7 @@
 'aiofiles>=0.8.0' # allow later versions, tested with 22.1.0
 'ipywidgets>=7.6.5' # allow later versions, tested with 0.8.0
 'xxhash>=3.0.0' # allow later versions, tested with 3.1.0
-'blis>=0.7.5' # allow later versions, tested with 0.7.9
+'blis>=0.7.5' # allow later versions, tested with 0.7.9, avoid 1.0.0 (depends on numpy 2)
 'click>=8.0.4' # allow later versions, tested with 8.1.3
 'pydantic>=1.10.0,<2.0' # for spacy compatibility; avoid 2.0 due to breaking changes
 "humanfriendly~=10.0"  # for human readable file / RAM sizes


### PR DESCRIPTION
`blis==1.0.0` is automatically installed, even though it depends on `numpy>=2.0.0,<3.0.0 ` (which is not compatible).
This shouldn't really happen. `pip` should recognise that`blis==1.0.0` is not compatible.

Regardless, this PR will pin `blis` to less than 1.0.0.


PS:
First GHA will fail (on python 3.8) to demonstrate the failure by default.