### PR TITLE
CU-8694fwyje: Update all configs with pre-load parts documented

### DIFF
--- a/medcat/config.py
+++ b/medcat/config.py
@@ -350,6 +350,9 @@ class General(MixingConfig, BaseModel):
     spacy_disabled_components: list = ['ner', 'parser', 'vectors', 'textcat',
                                        'entity_linker', 'sentencizer', 'entity_ruler', 'merge_noun_chunks',
                                        'merge_entities', 'merge_subtokens']
+    """The list of spacy components that will be disabled.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     checkpoint: CheckPoint = CheckPoint()
     usage_monitor = UsageMonitor()
     """Checkpointing config"""
@@ -412,9 +415,13 @@ class Preprocessing(MixingConfig, BaseModel):
     min_len_normalize: int = 5
     """Nothing below this length will ever be normalized (input tokens or concept names), normalized means lemmatized in this case"""
     stopwords: Optional[set] = None
-    """If None the default set of stowords from spacy will be used. This must be a Set."""
+    """If None the default set of stowords from spacy will be used. This must be a Set.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     max_document_length: int = 1000000
-    """Documents longer  than this will be trimmed"""
+    """Documents longer  than this will be trimmed.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
 
     class Config:
         extra = Extra.allow

--- a/medcat/config_meta_cat.py
+++ b/medcat/config_meta_cat.py
@@ -7,10 +7,16 @@ class General(MixingConfig, BaseModel):
     device: str = 'cpu'
     disable_component_lock: bool = False
     seed: int = 13
+    """The seed for random number generation.
+
+    NOTE: If used along RelCAT or additional NER, only one of the seeds will take effect
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     description: str = "No description"
     """Should provide a basic description of this MetaCAT model"""
     category_name: Optional[str] = None
-    """What category is this meta_cat model predicting/training"""
+    """What category is this meta_cat model predicting/training.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     category_value2id: Dict = {}
     """Map from category values to ID, if empty it will be autocalculated during training"""
     vocab_size: Optional[int] = None
@@ -28,7 +34,9 @@ class General(MixingConfig, BaseModel):
     annotate_overlapping: bool = False
     """If set meta_anns will be calcualted for doc._.ents, otherwise for doc.ents"""
     tokenizer_name: str = 'bbpe'
-    """Tokenizer name used with of MetaCAT"""
+    """Tokenizer name used with of MetaCAT.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     save_and_reuse_tokens: bool = False
     """This is a dangerous option, if not sure ALWAYS set to False. If set, it will try to share the pre-calculated
     context tokens between MetaCAT models when serving. It will ignore differences in tokenizer and context size,
@@ -48,13 +56,34 @@ class General(MixingConfig, BaseModel):
 class Model(MixingConfig, BaseModel):
     """The model part of the metaCAT config"""
     model_name: str = 'lstm'
-    """NOTE: When changing model, make sure to change the tokenizer as well"""
+    """The name/type of the model.
+
+    NOTE: When changing model, make sure to change the tokenizer as well.
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     model_variant: str = 'bert-base-uncased'
+    """The model variant in case of BERT metaCAT.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     model_freeze_layers: bool = True
+    """Whether to freeze model layers.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     num_layers: int = 2
+    """The number of layers.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     input_size: int = 300
+    """The input size.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     hidden_size: int = 300
+    """The hideen size.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     dropout: float = 0.5
+    """The dropout for the model.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     phase_number: int = 0
     """Indicates whether or not two phase learning is being performed.
     1: Phase 1 - Train model on undersampled data
@@ -62,13 +91,25 @@ class Model(MixingConfig, BaseModel):
     0: None - 2 phase learning is not performed"""
     category_undersample: str = ''
     model_architecture_config: Dict = {'fc2': True, 'fc3': False,'lr_scheduler': True}
+    """The model architecture config.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     num_directions: int = 2
-    """2 - bidirectional model, 1 - unidirectional"""
+    """2 - bidirectional model, 1 - unidirectional.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     nclasses: int = 2
-    """Number of classes that this model will output"""
+    """Number of classes that this model will output.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     padding_idx: int = -1
+    """The padding index.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     emb_grad: bool = True
-    """If True the embeddings will also be trained"""
+    """If True the embeddings will also be trained.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     ignore_cpos: bool = False
     """If set to True center positions will be ignored when calculating representation"""
 

--- a/medcat/config_rel_cat.py
+++ b/medcat/config_rel_cat.py
@@ -6,6 +6,9 @@ from medcat.config import MixingConfig, BaseModel, Optional, Extra
 class General(MixingConfig, BaseModel):
     """The General part of the RelCAT config"""
     device: str = "cpu"
+    """The device to use (CPU or GPU).
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     relation_type_filter_pairs: List = []
     """Map from category values to ID, if empty it will be autocalculated during training"""
     vocab_size: Optional[int] = None
@@ -24,10 +27,25 @@ class General(MixingConfig, BaseModel):
     """When processing relations from a MedCAT export, relations labeled as 'Other' are created from all the annotations pairs available"""
 
     tokenizer_name: str = "bert"
+    """The name of the tokenizer user.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     model_name: str = "bert-base-uncased"
+    """The name of the model used.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     log_level: int = logging.INFO
+    """The log level for RelCAT.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     max_seq_length: int = 512
+    """The maximum sequence length.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     tokenizer_special_tokens: bool = False
+    """Tokenizer.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     annotation_schema_tag_ids: List = []
     """If a foreign non-MCAT trainer dataset is used, you can insert your own Rel entity token delimiters into the tokenizer, \
     copy those token IDs here, and also resize your tokenizer embeddings and adjust the hidden_size of the model, this will depend on the number of tokens you introduce"""
@@ -35,16 +53,31 @@ class General(MixingConfig, BaseModel):
     idx2labels: Dict = {}
     pin_memory: bool = True
     seed: int = 13
+    """The seed for random number generation.
+
+    NOTE: If used along MetaCAT or additional NER, only one of the seeds will take effect
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     task: str = "train"
+    """The task for RelCAT.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
 
 
 class Model(MixingConfig, BaseModel):
     """The model part of the RelCAT config"""
     input_size: int = 300
     hidden_size: int = 768
+    """The hidden size.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     hidden_layers: int = 3
-    """ hidden_size * 5, 5 being the number of tokens, default (s1,s2,e1,e2+CLS)"""
+    """ hidden_size * 5, 5 being the number of tokens, default (s1,s2,e1,e2+CLS).
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     model_size: int = 5120
+    """The size of the model.
+
+    NB! For these changes to take effect, the pipe would need to be recreated."""
     dropout: float = 0.2
     num_directions: int = 2
     """2 - bidirectional model, 1 - unidirectional"""


### PR DESCRIPTION
This would be an alternative to #447 

The idea is to document the various config entries that need the recreation of the pipe to take effect.

Whereas #447 made the change in a strict way by moving all the pre-load config options to their own section of the config, this one just documents the pre-load nature (or the need to recreate the pipe) of thee entries.

The benefits of this (over #447) are the following:
- No need to add and maintain a translation layer for backwards compatibility
  - I.e when loading old models, the #447 needs to translate the old config entries into the new format
- Lower risk of downstream breakage
  - For something that depends on `MedCAT`
    - E.g `working_with_cogstack`, `MedCATtrainer`
  - With #447, the expected change to a relevant config entry would not have raised an exception but also wouldn't have changed the behaviour
    - Due to some parts of `MedCAT` allowing arbitrary new config entries, they are currently allowed
    - There would be a way to mitigate this in #447, but that would include even more code to add and maintain