### PR TITLE
Use the loaded model hash for usage monitor instead of recalculating it

### DIFF
--- a/medcat/cat.py
+++ b/medcat/cat.py
@@ -109,7 +109,7 @@ class CAT(object):
         self._rel_cats = rel_cats
         self._addl_ner = addl_ner if isinstance(addl_ner, list) else [addl_ner]
         self._create_pipeline(self.config)
-        self.usage_monitor = UsageMonitor(self.get_hash(), self.config.general.usage_monitor)
+        self.usage_monitor = UsageMonitor(self.config.version.id, self.config.general.usage_monitor)
 
     def _create_pipeline(self, config: Config):
         # Set log level


### PR DESCRIPTION
The UsageMonitor PR #458 missed something.

Since the usage monitor is attempting to save to a file that has the hash of the model as part of its name, it is looking for the model's hash upon initialisation. The assumption is that this can easily be found since the CDB carries its hash with it (since #286 / release 1.8.0). However, older models did not have the CDB hash saved. As such, during the creation of the usage monitoring, the CDB hash was calculated.

Now, this PR will change the behaviour and use the hash that's in `config.version.id` instead of recalculating it. 