### PR TITLE
CU-8695jwnjk: Fix description of an argument for --help to work in CLI

### DIFF
--- a/medcat/utils/regression/regression_checker.py
+++ b/medcat/utils/regression/regression_checker.py
@@ -166,7 +166,7 @@ if __name__ == '__main__':
     parser.add_argument('--only-describe', help='Only describe the various findings and exit.',
                         action='store_true')
     parser.add_argument('--require-fully-correct', help='Require the regression test to be fully correct. '
-                        'If set, a non-zero exit status is returned unless all cases are successful (100%). '
+                        'If set, a non-zero exit status is returned unless all cases are successful (100%%). '
                         'This can be useful for (e.g) CI workflow integration.',
                         action='store_true')
     args = parser.parse_args()


### PR DESCRIPTION
Turns out the `%` in the description for an argument broke the argument help (i.e `--help`).

This PR fixes that by escaping the `%`.

<details>
<summary>Longer description of issue</summary>

Turns out `python -m medcat.utils.regression.regression_checker --help`  raises an exception due to a description having `%`  in it, e.g:

```
Traceback (most recent call last):
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/medcat/utils/regression/regression_checker.py", line 172, in <module>
    args = parser.parse_args()
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 1833, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 1866, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 2079, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 2019, in consume_optional
    take_action(action, args, option_string)
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 1943, in take_action
    action(self, namespace, argument_values, option_string)
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 1106, in __call__
    parser.print_help()
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 2567, in print_help
    self._print_message(self.format_help(), file)
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 2551, in format_help
    return formatter.format_help()
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 283, in format_help
    help = self._root_section.format_help()
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 214, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 214, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 214, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 214, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 540, in _format_action
    help_text = self._expand_help(action)
  File "/Users/martratas/.pyenv/versions/3.10.13/lib/python3.10/argparse.py", line 637, in _expand_help
    return self._get_help_string(action) % params
ValueError: unsupported format character ')' (0x29) at index 129
```
</details>