### PR TITLE
CU-8695knfbg Add name edits to regression suite

### DIFF
--- a/medcat/utils/normalizers.py
+++ b/medcat/utils/normalizers.py
@@ -145,14 +145,14 @@ def get_all_edits_n(word: str, use_diacritics: bool, n: int,
     Yields:
         Iterator[str]: The generator of the various edits.
     """
+    if n < 0:
+        raise ValueError(f"Unknown edit count: {n}")
     if n == 0:
         yield word
     elif n == 1:
         edits = BasicSpellChecker.get_edits1(word, use_diacritics)
         f_edits = sorted(edits) if return_ordered else edits
         yield from f_edits
-    elif n < 0:
-        raise ValueError(f"Unknown edit count: {n}")
     else:
         edits1 = BasicSpellChecker.get_edits1(word, use_diacritics)
         f_edits = sorted(edits1) if return_ordered else edits1

--- a/medcat/utils/normalizers.py
+++ b/medcat/utils/normalizers.py
@@ -149,15 +149,14 @@ def get_all_edits_n(word: str, use_diacritics: bool, n: int,
         raise ValueError(f"Unknown edit count: {n}")
     if n == 0:
         yield word
-    elif n == 1:
-        edits = BasicSpellChecker.get_edits1(word, use_diacritics)
-        f_edits = sorted(edits) if return_ordered else edits
+        return
+    edits = BasicSpellChecker.get_edits1(word, use_diacritics)
+    f_edits = sorted(edits) if return_ordered else edits
+    if n == 1:
         yield from f_edits
-    else:
-        edits1 = BasicSpellChecker.get_edits1(word, use_diacritics)
-        f_edits = sorted(edits1) if return_ordered else edits1
-        for edited_word in f_edits:
-            yield from get_all_edits_n(edited_word, use_diacritics, n - 1, return_ordered)
+        return
+    for edited_word in f_edits:
+        yield from get_all_edits_n(edited_word, use_diacritics, n - 1, return_ordered)
 
 
 class TokenNormalizer(PipeRunner):

--- a/medcat/utils/normalizers.py
+++ b/medcat/utils/normalizers.py
@@ -82,15 +82,30 @@ class BasicSpellChecker(object):
         return set(w for w in words if w in self.vocab)
 
     def edits1(self, word: str) -> Set[str]:
+        return self.get_edits1(word, self.config.general.diacritics)
+
+    @classmethod
+    def get_edits1(cls, word: str, use_diacritics: bool) -> Set[str]:
         """All edits that are one edit away from `word`.
 
         Args:
             word (str): The word.
+            use_diacritics (bool): Whether to use diacritics or not.
 
         Returns:
             Set[str]: The set of all edits
         """
-        return get_all_edits(word, self.config.general.diacritics)
+        letters    = 'abcdefghijklmnopqrstuvwxyz'
+
+        if use_diacritics:
+            letters += 'àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ'
+
+        splits     = [(word[:i], word[i:])    for i in range(len(word) + 1)]
+        deletes    = [L + R[1:]               for L, R in splits if R]
+        transposes = [L + R[1] + R[0] + R[2:] for L, R in splits if len(R)>1]
+        replaces   = [L + c + R[1:]           for L, R in splits if R for c in letters]
+        inserts    = [L + c + R               for L, R in splits for c in letters]
+        return set(deletes + transposes + replaces + inserts)
 
     def edits2(self, word: str) -> Iterator[str]:
         """All edits that are two edits away from `word`.
@@ -101,55 +116,12 @@ class BasicSpellChecker(object):
         Returns:
             Iterator[str]: All 2-away edits.
         """
-        return get_all_edits_2(word, self.config.general.diacritics)
+        return (e2 for e1 in self.edits1(word) for e2 in self.edits1(e1))
 
     def edits3(self, word):
         """All edits that are two edits away from `word`."""  # noqa
         # Do d3 edits
         pass
-
-
-def get_all_edits(word: str, use_diacritics: bool) -> Set[str]:
-    """Gets all the 1-distances edits of a word.
-
-    Args:
-        word (str): The word in question.
-        use_diacritics (bool): Whether or not to use diacritics.
-
-    Returns:
-        Set[str]: All the possibile edits.
-    """
-    letters    = 'abcdefghijklmnopqrstuvwxyz'
-
-    if use_diacritics:
-        letters += 'àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ'
-
-    splits     = [(word[:i], word[i:])    for i in range(len(word) + 1)]
-    deletes    = [L + R[1:]               for L, R in splits if R]
-    transposes = [L + R[1] + R[0] + R[2:] for L, R in splits if len(R)>1]
-    replaces   = [L + c + R[1:]           for L, R in splits if R for c in letters]
-    inserts    = [L + c + R               for L, R in splits for c in letters]
-    return set(deletes + transposes + replaces + inserts)
-
-
-def get_all_edits_2(word: str, use_diacritics: bool,
-                    return_ordered: bool = False) -> Iterator[str]:
-    """Gets all the 2-distance edits of a word.
-
-    Args:
-        word (str): The word in question.
-        use_diacritics (bool): Whether or not to use diacritics
-        return_ordered (bool): Whether or not to use an ordered list of edits
-
-    Returns:
-        Iterator[Str]: Generator of all the possible words.
-    """
-    raw_fo_edits = get_all_edits(word, use_diacritics)
-    first_order_edits = sorted(raw_fo_edits) if return_ordered else raw_fo_edits
-    return (e2 for e1 in first_order_edits
-            for e2 in (sorted(get_all_edits(e1, use_diacritics))
-                       if return_ordered else
-                        get_all_edits(e1, use_diacritics)))
 
 
 def get_all_edits_n(word: str, use_diacritics: bool, n: int,
@@ -176,16 +148,16 @@ def get_all_edits_n(word: str, use_diacritics: bool, n: int,
     if n == 0:
         yield word
     elif n == 1:
-        edits = get_all_edits(word, use_diacritics)
+        edits = BasicSpellChecker.get_edits1(word, use_diacritics)
         f_edits = sorted(edits) if return_ordered else edits
         yield from f_edits
-    elif n == 2:
-        yield from get_all_edits_2(word, use_diacritics, return_ordered)
     elif n < 0:
         raise ValueError(f"Unknown edit count: {n}")
     else:
-        for edited_word in get_all_edits_2(word, use_diacritics, return_ordered):
-            yield from get_all_edits_n(edited_word, use_diacritics, n - 2, return_ordered)
+        edits1 = BasicSpellChecker.get_edits1(word, use_diacritics)
+        f_edits = sorted(edits1) if return_ordered else edits1
+        for edited_word in f_edits:
+            yield from get_all_edits_n(edited_word, use_diacritics, n - 1, return_ordered)
 
 
 class TokenNormalizer(PipeRunner):

--- a/medcat/utils/regression/checking.py
+++ b/medcat/utils/regression/checking.py
@@ -104,7 +104,7 @@ class RegressionCase(BaseModel):
             name_variant = 0
             if edit_dist:# TODO: use config.ner.min_name_len or something
                 name_gen = get_all_edits_n(
-                    raw_name, use_diacritics, edit_dist)
+                    raw_name, use_diacritics, edit_dist, return_ordered=True)
                 all_names = list(pick_random_edits(name_gen, edit_pick, len(raw_name),
                                                    edit_dist, edit_rn_seed))
             else:

--- a/medcat/utils/regression/checking.py
+++ b/medcat/utils/regression/checking.py
@@ -12,7 +12,9 @@ from medcat.cat import CAT
 from medcat.utils.regression.targeting import TranslationLayer, OptionSet
 from medcat.utils.regression.targeting import FinalTarget, TargetedPhraseChanger
 from medcat.utils.regression.utils import partial_substitute, MedCATTrainerExportConverter
+from medcat.utils.regression.utils import pick_random_edits
 from medcat.utils.regression.results import MultiDescriptor, ResultDescriptor, Finding
+from medcat.utils.normalizers import get_all_edits_n
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +71,9 @@ class RegressionCase(BaseModel):
     def estimate_num_of_diff_subcases(self) -> int:
         return len(self.phrases) * self.options.estimate_num_of_subcases()
 
-    def get_distinct_cases(self, translation: TranslationLayer) -> Iterator[Iterator[FinalTarget]]:
+    def get_distinct_cases(self, translation: TranslationLayer,
+                           edit_distance: Tuple[int, int, int],
+                           use_diacritics: bool) -> Iterator[Iterator[FinalTarget]]:
         """Gets the various distinct sub-case iterators.
 
         The sub-cases are those that can be determine without the translation layer.
@@ -77,6 +81,8 @@ class RegressionCase(BaseModel):
 
         Args:
             translation (TranslationLayer): The translation layer.
+            edit_distance (Tuple[int, int, int]): The edit distance(s) to try.
+            use_diacritics (bool): Whether to use diacritics for edit distance.
 
         Yields:
             Iterator[Iterator[FinalTarget]]: The iterator of iterators of different sub cases.
@@ -84,24 +90,43 @@ class RegressionCase(BaseModel):
         # for each phrase and for each placeholder based option
         for changer in self.options.get_preprocessors_and_targets(translation):
             for phrase in self.phrases:
-                yield self._get_subcases(phrase, changer, translation)
+                yield self._get_subcases(phrase, changer, translation, edit_distance, use_diacritics)
 
     def _get_subcases(self, phrase: str, changer: TargetedPhraseChanger,
-                      translation: TranslationLayer) -> Iterator[FinalTarget]:
+                      translation: TranslationLayer,
+                      edit_distance: Tuple[int, int, int],
+                      use_diacritics: bool,
+                      ) -> Iterator[FinalTarget]:
         cui, placeholder = changer.cui, changer.placeholder
         changed_phrase = changer.changer(phrase)
-        for name in translation.get_names_of(cui, changer.onlyprefnames):
-            num_of_phs = changed_phrase.count(placeholder)
-            if num_of_phs == 1:
-                yield FinalTarget(placeholder=placeholder,
-                                  cui=cui, name=name,
-                                  final_phrase=changed_phrase)
-                continue
-            for cntr in range(num_of_phs):
-                final_phrase = partial_substitute(changed_phrase, placeholder, name, cntr)
-                yield FinalTarget(placeholder=placeholder,
-                                  cui=cui, name=name,
-                                  final_phrase=final_phrase)
+        edit_dist, edit_rn_seed, edit_pick = edit_distance
+        for raw_name in translation.get_names_of(cui, changer.onlyprefnames):
+            name_variant = 0
+            if edit_dist:# TODO: use config.ner.min_name_len or something
+                name_gen = get_all_edits_n(
+                    raw_name, use_diacritics, edit_dist)
+                all_names = list(pick_random_edits(name_gen, edit_pick, len(raw_name),
+                                                   edit_dist, edit_rn_seed))
+            else:
+                all_names = [raw_name]
+            for name in all_names:
+                if edit_dist:
+                    logger.debug("Changed name from '%s' to '%s' (variant %d, edit distance %s, "
+                                 "seed %d, picking %d)",
+                                 raw_name, name, name_variant, edit_dist,
+                                 edit_rn_seed, edit_pick)
+                    name_variant += 1
+                num_of_phs = changed_phrase.count(placeholder)
+                if num_of_phs == 1:
+                    yield FinalTarget(placeholder=placeholder,
+                                    cui=cui, name=name,
+                                    final_phrase=changed_phrase)
+                    continue
+                for cntr in range(num_of_phs):
+                    final_phrase = partial_substitute(changed_phrase, placeholder, name, cntr)
+                    yield FinalTarget(placeholder=placeholder,
+                                    cui=cui, name=name,
+                                    final_phrase=final_phrase)
 
     def to_dict(self) -> dict:
         """Converts the RegressionCase to a dict for serialisation.
@@ -293,7 +318,9 @@ class RegressionSuite:
         for case in self.cases:
             self.report.parts.append(case.report)
 
-    def get_all_distinct_cases(self, translation: TranslationLayer
+    def get_all_distinct_cases(self, translation: TranslationLayer,
+                               edit_distance: Tuple[int, int, int],
+                               use_diacritics: bool
                                ) -> Iterator[Tuple[RegressionCase, Iterator[FinalTarget]]]:
         """Gets all the distinct cases for this regression suite.
 
@@ -302,13 +329,17 @@ class RegressionSuite:
 
         Args:
             translation (TranslationLayer): The translation layer.
+            edit_distance (Tuple[int, int, int]): The edit distance(s) to try.
+                Defaults to (0, 0, 0).
+            use_diacritics (bool): Whether to use diacritics for edit distance.
 
         Yields:
             Iterator[Tuple[RegressionCase, Iterator[FinalTarget]]]: The generator of the
                 regression case along with its corresponding sub-cases.
         """
         for regr_case in self.cases:
-            for subcase in regr_case.get_distinct_cases(translation):
+            for subcase in regr_case.get_distinct_cases(translation, edit_distance,
+                                                        use_diacritics):
                 yield regr_case, subcase
 
     def estimate_total_distinct_cases(self) -> int:
@@ -316,6 +347,8 @@ class RegressionSuite:
 
     def iter_subcases(self, translation: TranslationLayer,
                       show_progress: bool = True,
+                      edit_distance: Tuple[int, int, int] = (0, 0, 0),
+                      use_diacritics: bool = False,
                       ) -> Iterator[Tuple[RegressionCase, FinalTarget]]:
         """Iterate over all the sub-cases.
 
@@ -325,28 +358,40 @@ class RegressionSuite:
         Args:
             translation (TranslationLayer): The translation layer.
             show_progress (bool): Whether to show progress. Defaults to True.
+            edit_distance (Tuple[int, int, int]): The edit distance(s) to try.
+                Defaults to (0, 0, 0).
+            use_diacritics (bool): Whether to use diacritics for edit distance.
 
         Yields:
             Iterator[Tuple[RegressionCase, FinalTarget]]: The generator of the
                 regression case along with each of the final target sub-cases.
         """
         total = self.estimate_total_distinct_cases()
-        for (regr_case, subcase) in tqdm.tqdm(self.get_all_distinct_cases(translation),
+        for (regr_case, subcase) in tqdm.tqdm(self.get_all_distinct_cases(translation,
+                                                                          edit_distance,
+                                                                          use_diacritics),
                                               total=total, disable=not show_progress):
             for target in subcase:
                 yield regr_case, target
 
-    def check_model(self, cat: CAT, translation: TranslationLayer) -> MultiDescriptor:
+    def check_model(self, cat: CAT, translation: TranslationLayer,
+                    edit_distance: Tuple[int, int, int] = (0, 0, 0),
+                    use_diacritics: bool = False,
+                    ) -> MultiDescriptor:
         """Checks model and generates a report
 
         Args:
             cat (CAT): The model to check against
             translation (TranslationLayer): The translation layer
+            edit_distance (Tuple[int, int, int]): The edit distance of the names.
+                Defaults to (0, 0, 0).
+            use_diacritics (bool): Whether to use diacritics for edit distance.
 
         Returns:
             MultiDescriptor: A report description
         """
-        for regr_case, target in self.iter_subcases(translation, True):
+        for regr_case, target in self.iter_subcases(translation, True,
+                                                    edit_distance, use_diacritics):
             # NOTE: the finding is reported in the per-case report
             regr_case.check_specific_for_phrase(cat, target, translation)
         return self.report

--- a/medcat/utils/regression/regression_checker.py
+++ b/medcat/utils/regression/regression_checker.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 import logging
 
-from typing import Optional
+from typing import Optional, Tuple
 
 from medcat.cat import CAT
 from medcat.utils.regression.checking import RegressionSuite, TranslationLayer
@@ -47,7 +47,8 @@ def main(model_pack_dir: Path, test_suite_file: Path,
          mct_export_yaml_path: Optional[str] = None,
          only_mct_export_conversion: bool = False,
          only_describe: bool = False,
-         require_fully_correct: bool = False) -> None:
+         require_fully_correct: bool = False,
+         edit_distance: Tuple[int, int, int] = (0, 0, 0)) -> None:
     """Check test suite against the specifeid model pack.
 
     Args:
@@ -72,6 +73,11 @@ def main(model_pack_dir: Path, test_suite_file: Path,
         require_fully_correct (bool): Whether all cases are required to be correct.
             If set to True, an exit-status of 1 is returned unless all (sub)cases are correct.
             Defaults to False.
+        edit_distance (Tuple[int, int, int]): The edit distance, the random seed, and the number
+            of edited names to pick for each of the names. If set to non-0, the specified number
+            of splits, deletes, transposes, replaces, or inserts are done to the each name. This
+            can be useful for looking at the capability of identifying typos in text. However,
+            this can make hte process a lot slower as a resullt. Defaults to (0, 0, 0).
 
     Raises:
         ValueError: If unable to overwrite file or folder does not exist.
@@ -101,7 +107,10 @@ def main(model_pack_dir: Path, test_suite_file: Path,
     logger.info('Loading model pack from file: %s', model_pack_dir)
     cat: CAT = CAT.load_model_pack(str(model_pack_dir))
     logger.info('Checking the current status')
-    res = rc.check_model(cat, TranslationLayer.from_CDB(cat.cdb))
+    res = rc.check_model(cat, TranslationLayer.from_CDB(cat.cdb),
+                         edit_distance=edit_distance,
+                         use_diacritics=cat.config.general.diacritics)
+    cat.config.general
     strictness = Strictness[strictness_str]
     if examples_strictness_str in ("None", "N/A"):
         examples_strictness = None
@@ -121,6 +130,16 @@ def main(model_pack_dir: Path, test_suite_file: Path,
                                               strictness=strictness, phrase_max_len=max_phrase_length)[:2]
         if total != success:
             exit(1)
+
+
+def tuple3_parser(arg: str) -> Tuple[int, int, int]:
+    parts = arg.strip("()").split(',')
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError("Tuple must be in the form (x, y, z)")
+    try:
+        return (int(parts[0]), int(parts[1]), int(parts[2]))
+    except ValueError:
+        raise argparse.ArgumentTypeError("Tuple must be in the form (x, y, z)")
 
 
 if __name__ == '__main__':
@@ -169,6 +188,19 @@ if __name__ == '__main__':
                         'If set, a non-zero exit status is returned unless all cases are successful (100%). '
                         'This can be useful for (e.g) CI workflow integration.',
                         action='store_true')
+    parser.add_argument('--edit-distance', help='Set the edit distance of each of the names. '
+                        'If set, each name tested will have the specified number of characters changed. '
+                        'This can be useful to determine the versatility of the model in terms of '
+                        'recognising typos. Defauts to 0 (i.e no change). You need to provide 3 numbers '
+                        'in the format `(N, R, P)` where `N` is the edit distance, `R` is the random seed, '
+                        'and `P` is the number of choices to make.',
+                        # ' NOTE: Edit distances greater '
+                        # 'than 1 will add an expenentially higher and higher number of sub-cases and thus '
+                        # 'time for the regression suite to be run. Even at edit distance 2 you can have '
+                        # '500 000 different variants for a 15 character long name and the longer the name, '
+                        # 'the more varions you get. For instance, a 76 characater long name could have '
+                        # 'upwards of 15 million varaints.',
+                        type=tuple3_parser, default=(0, 0, 0))
     args = parser.parse_args()
     if not args.silent:
         logger.addHandler(logging.StreamHandler())
@@ -183,4 +215,4 @@ if __name__ == '__main__':
          strictness_str=args.strictness, max_phrase_length=args.max_phrase_length,
          use_mct_export=args.from_mct_export, mct_export_yaml_path=args.mct_export_yaml,
          only_mct_export_conversion=args.only_conversion, only_describe=args.only_describe,
-         require_fully_correct=args.require_fully_correct)
+         require_fully_correct=args.require_fully_correct, edit_distance=args.edit_distance)

--- a/medcat/utils/regression/targeting.py
+++ b/medcat/utils/regression/targeting.py
@@ -68,7 +68,11 @@ class TranslationLayer:
         if only_prefnames:
             return [self.get_preferred_name(cui).replace(self.separator, self.whitespace)]
         return [name.replace(self.separator, self.whitespace)
-                   for name in self.cui2names.get(cui, [])]
+                   # NOTE: sorting the order here in case we're using
+                   #       edirts in which case the order of the names
+                   #       needs to be the same, otherwise different
+                   #       edits will be used across runs
+                   for name in sorted(self.cui2names.get(cui, []))]
 
     def get_preferred_name(self, cui: str) -> str:
         """Get the preferred name of a concept.

--- a/tests/utils/test_normalizers.py
+++ b/tests/utils/test_normalizers.py
@@ -1,0 +1,71 @@
+import unittest
+
+from medcat.utils import normalizers
+
+
+class EditOrderTests(unittest.TestCase):
+    WORD = "abc"
+    EXMAPLE_EDITS_ORDER = [
+            'abqc', 'rbc', 'obc', 'fbc', 'abyc',
+            'azbc', 'ibc', 'xbc', 'apc', 'abcl',
+            'abcr', 'abck', 'anc', 'abd', 'abkc',
+            'iabc', 'tbc', 'cabc', 'abw', 'abp',
+            'abe', 'akbc', 'apbc', 'hbc', 'ubc',
+            'abic', 'babc', 'abcq', 'wabc', 'abtc',
+            'aibc', 'yabc', 'asc', 'abrc', 'avbc',
+            'abu', 'kabc', 'axc', 'fabc', 'nbc',
+            'rabc', 'abec', 'abcu', 'gbc', 'amc',
+            'abce', 'abdc', 'abcy', 'bbc', 'dbc',
+            'abac', 'abvc', 'abuc', 'avc', 'abi',
+            'abm', 'abjc', 'abcp', 'tabc', 'cbc',
+            'uabc', 'abz', 'aby', 'qbc', 'abcf',
+            'abpc', 'axbc', 'abk', 'gabc', 'abc',
+            'mbc', 'aqbc', 'abci', 'oabc', 'qabc',
+            'abf', 'vabc', 'abj', 'abbc', 'aubc',
+            'acbc', 'abn', 'aebc', 'ebc', 'abfc',
+            'dabc', 'abh', 'arc', 'aqc', 'albc',
+            'aac', 'abcb', 'sabc', 'ybc', 'abcv',
+            'absc', 'abca', 'labc', 'ajbc', 'kbc',
+            'pabc', 'abcc', 'afbc', 'sbc', 'abl',
+            'awc', 'ahbc', 'abco', 'anbc', 'abo',
+            'abg', 'abcn', 'awbc', 'adc', 'ahc',
+            'habc', 'abb', 'vbc', 'aboc', 'abq',
+            'acc', 'agc', 'abcx', 'nabc', 'abwc',
+            'lbc', 'abcm', 'afc', 'ab', 'atc',
+            'aybc', 'akc', 'abt', 'aic', 'jbc',
+            'aec', 'zabc', 'agbc', 'abv', 'abnc',
+            'abcj', 'pbc', 'abcg', 'bac', 'abr',
+            'aobc', 'abcd', 'alc', 'aoc', 'ajc',
+            'abx', 'arbc', 'ayc', 'aba', 'abcw',
+            'eabc', 'abcs', 'abhc', 'adbc', 'abgc',
+            'asbc', 'acb', 'abs', 'aabc', 'abzc',
+            'abxc', 'atbc', 'ambc', 'jabc', 'bc',
+            'wbc', 'abcz', 'ablc', 'ac', 'azc',
+            'abct', 'abmc', 'zbc', 'abch', 'auc',
+            'xabc', 'mabc'
+        ]
+
+    # NOTE: The there is a chance that this test fails. But it should be 2 in 182!
+    #       (since I'm checking against 2 different orders - the one captured above
+    #       and the alphabetically ordered version calculated on the fly). This is
+    #       essentially 0 and _should_ never happen.
+    def test_order_not_guaranteed1(self):
+        all_edits = list(normalizers.get_all_edits_n(self.WORD, use_diacritics=False, n=1, return_ordered=False))
+        self.assertNotEqual(all_edits, self.EXMAPLE_EDITS_ORDER)
+        self.assertNotEqual(all_edits, sorted(all_edits))
+
+    def test_ordered_within_same_run1(self):
+        all_edits1 = list(normalizers.get_all_edits_n(self.WORD, use_diacritics=False, n=1, return_ordered=False))
+        all_edits2 = list(normalizers.get_all_edits_n(self.WORD, use_diacritics=False, n=1, return_ordered=False))
+        self.assertEqual(all_edits1, all_edits2)
+
+    def test_all_items_same_now1(self):
+        all_edits = list(normalizers.get_all_edits_n(self.WORD, use_diacritics=False, n=1, return_ordered=False))
+        for got_now in all_edits:
+            with self.subTest(got_now):
+                self.assertIn(got_now, self.EXMAPLE_EDITS_ORDER)
+
+    def test_can_guarantee_order1(self):
+        all_edits1 = list(normalizers.get_all_edits_n(self.WORD, use_diacritics=False, n=1, return_ordered=True))
+        ordered = sorted(all_edits1)
+        self.assertEqual(all_edits1, ordered)


### PR DESCRIPTION
Add option (`--edit-distance`) to specify name edit distance as a tuple (edit distance, random number generator seed, and number of picks).

We need to pick a subset of the edits since otherwise there can be thousands of edits checked - and that would slow down the process considerably.

And to avoid run-to-run variance we need to be able to specify a random seed for the picks.

<details>
<summary>Examples</summary>

Example without edit-distance:

```
$ python -m medcat.utils.regression.regression_checker models/20230227__kch_gstt_trained_model_494c3717f637bb89.zip --example-strictness None
Loading RegressionChecker from yaml: configs/default_regression_tests.yml
Loading model pack from file: models/20230227__kch_gstt_trained_model_494c3717f637bb89.zip
Checking the current status
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [02:39<00:00,  1.26it/s]
A total of 2 parts were kept track of within the group "default_regression_tests.yml".
And a total of 4469 (sub)cases were checked.
At the strictness level of Strictness.NORMAL (allowing ['FOUND_ANY_CHILD', 'BIGGER_SPAN_BOTH', 'BIGGER_SPAN_RIGHT', 'BIGGER_SPAN_LEFT', 'PARTIAL_OVERLAP', 'SMALLER_SPAN', 'IDENTICAL', 'FOUND_CHILD_PARTIAL']):
The number of total successful (sub) cases: 4289 (95.97%)
The number of total failing (sub) cases   : 180 ( 4.03%)
IDENTICAL               :      4234 (94.74%)
SMALLER_SPAN            :         1 ( 0.02%)
FOUND_DIR_PARENT        :        27 ( 0.60%)
FOUND_ANY_CHILD         :        54 ( 1.21%)
FOUND_OTHER             :       132 ( 2.95%)
FAIL                    :        21 ( 0.47%)
	Tested 'test-case-1' for a total of 665 cases:
		IDENTICAL               :       649 (97.59%)
		SMALLER_SPAN            :         1 ( 0.15%)
		FOUND_ANY_CHILD         :         7 ( 1.05%)
		FOUND_OTHER             :         2 ( 0.30%)
		FAIL                    :         6 ( 0.90%)
	Tested 'test-case-2' for a total of 3804 cases:
		IDENTICAL               :      3585 (94.24%)
		FOUND_DIR_PARENT        :        27 ( 0.71%)
		FOUND_ANY_CHILD         :        47 ( 1.24%)
		FOUND_OTHER             :       130 ( 3.42%)
		FAIL                    :        15 ( 0.39%)
```

Example with edit distance:

```
$ python -m medcat.utils.regression.regression_checker models/20230227__kch_gstt_trained_model_494c3717f637bb89.zip --example-strictness None --edit-distance "(1,42,2)"
Loading RegressionChecker from yaml: configs/default_regression_tests.yml
Loading model pack from file: models/20230227__kch_gstt_trained_model_494c3717f637bb89.zip
Checking the current status
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [06:30<00:00,  1.95s/it]
A total of 2 parts were kept track of within the group "default_regression_tests.yml".
And a total of 8928 (sub)cases were checked.
At the strictness level of Strictness.NORMAL (allowing ['SMALLER_SPAN', 'BIGGER_SPAN_RIGHT', 'FOUND_ANY_CHILD', 'FOUND_CHILD_PARTIAL', 'BIGGER_SPAN_LEFT', 'BIGGER_SPAN_BOTH', 'IDENTICAL', 'PARTIAL_OVERLAP']):
The number of total successful (sub) cases: 7419 (83.10%)
The number of total failing (sub) cases   : 1509 (16.90%)
IDENTICAL               :      6772 (75.85%)
SMALLER_SPAN            :       546 ( 6.12%)
FOUND_DIR_PARENT        :        25 ( 0.28%)
FOUND_ANY_CHILD         :        88 ( 0.99%)
FOUND_CHILD_PARTIAL     :        13 ( 0.15%)
FOUND_OTHER             :       264 ( 2.96%)
FAIL                    :      1220 (13.66%)
	Tested 'test-case-1' for a total of 1329 cases:
		IDENTICAL               :       976 (73.44%)
		SMALLER_SPAN            :        95 ( 7.15%)
		FOUND_ANY_CHILD         :        11 ( 0.83%)
		FOUND_CHILD_PARTIAL     :         3 ( 0.23%)
		FOUND_OTHER             :         4 ( 0.30%)
		FAIL                    :       240 (18.06%)
	Tested 'test-case-2' for a total of 7599 cases:
		IDENTICAL               :      5796 (76.27%)
		SMALLER_SPAN            :       451 ( 5.93%)
		FOUND_DIR_PARENT        :        25 ( 0.33%)
		FOUND_ANY_CHILD         :        77 ( 1.01%)
		FOUND_CHILD_PARTIAL     :        10 ( 0.13%)
		FOUND_OTHER             :       260 ( 3.42%)
		FAIL                    :       980 (12.90%)
```

OR with the 2024-06 Snomed model (only trained on GSTT data).
Without edit distance:

```
 python -m medcat.utils.regression.regression_checker models/Snomed2024-06-gstt-trained_ae5b08e0fb5310b2.zip --example-strictness None                          
Loading RegressionChecker from yaml: configs/default_regression_tests.yml
Loading model pack from file: models/Snomed2024-06-gstt-trained_ae5b08e0fb5310b2.zip
Checking the current status
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [00:47<00:00,  4.21it/s]
A total of 2 parts were kept track of within the group "default_regression_tests.yml".
And a total of 4680 (sub)cases were checked.
At the strictness level of Strictness.NORMAL (allowing ['FOUND_ANY_CHILD', 'FOUND_CHILD_PARTIAL', 'BIGGER_SPAN_RIGHT', 'IDENTICAL', 'BIGGER_SPAN_BOTH', 'BIGGER_SPAN_LEFT', 'PARTIAL_OVERLAP', 'SMALLER_SPAN']):
The number of total successful (sub) cases: 4311 (92.12%)
The number of total failing (sub) cases   : 369 ( 7.88%)
IDENTICAL               :      4161 (88.91%)
SMALLER_SPAN            :         2 ( 0.04%)
FOUND_DIR_PARENT        :       191 ( 4.08%)
FOUND_DIR_GRANDPARENT   :        18 ( 0.38%)
FOUND_ANY_CHILD         :       148 ( 3.16%)
FOUND_OTHER             :       137 ( 2.93%)
FAIL                    :        23 ( 0.49%)
	Tested 'test-case-1' for a total of 756 cases:
		IDENTICAL               :       730 (96.56%)
		SMALLER_SPAN            :         2 ( 0.26%)
		FOUND_ANY_CHILD         :         5 ( 0.66%)
		FOUND_OTHER             :        18 ( 2.38%)
		FAIL                    :         1 ( 0.13%)
	Tested 'test-case-2' for a total of 3924 cases:
		IDENTICAL               :      3431 (87.44%)
		FOUND_DIR_PARENT        :       191 ( 4.87%)
		FOUND_DIR_GRANDPARENT   :        18 ( 0.46%)
		FOUND_ANY_CHILD         :       143 ( 3.64%)
		FOUND_OTHER             :       119 ( 3.03%)
		FAIL                    :        22 ( 0.56%)
```

With edit distance:

```
$ python -m medcat.utils.regression.regression_checker models/Snomed2024-06-gstt-trained_ae5b08e0fb5310b2.zip --example-strictness None --edit-distance "(1,42,2)" 
Loading RegressionChecker from yaml: configs/default_regression_tests.yml
Loading model pack from file: models/Snomed2024-06-gstt-trained_ae5b08e0fb5310b2.zip
Checking the current status
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 200/200 [02:00<00:00,  1.66it/s]
A total of 2 parts were kept track of within the group "default_regression_tests.yml".
And a total of 9354 (sub)cases were checked.
At the strictness level of Strictness.NORMAL (allowing ['PARTIAL_OVERLAP', 'BIGGER_SPAN_LEFT', 'BIGGER_SPAN_BOTH', 'FOUND_CHILD_PARTIAL', 'BIGGER_SPAN_RIGHT', 'SMALLER_SPAN', 'FOUND_ANY_CHILD', 'IDENTICAL']):
The number of total successful (sub) cases: 6149 (65.74%)
The number of total failing (sub) cases   : 3205 (34.26%)
IDENTICAL               :      5415 (57.89%)
SMALLER_SPAN            :       564 ( 6.03%)
FOUND_DIR_PARENT        :       241 ( 2.58%)
FOUND_DIR_GRANDPARENT   :        20 ( 0.21%)
FOUND_ANY_CHILD         :       151 ( 1.61%)
FOUND_CHILD_PARTIAL     :        19 ( 0.20%)
FOUND_OTHER             :       141 ( 1.51%)
FAIL                    :      2803 (29.97%)
	Tested 'test-case-1' for a total of 1512 cases:
		IDENTICAL               :       948 (62.70%)
		SMALLER_SPAN            :        94 ( 6.22%)
		FOUND_CHILD_PARTIAL     :         3 ( 0.20%)
		FOUND_OTHER             :        17 ( 1.12%)
		FAIL                    :       450 (29.76%)
	Tested 'test-case-2' for a total of 7842 cases:
		IDENTICAL               :      4467 (56.96%)
		SMALLER_SPAN            :       470 ( 5.99%)
		FOUND_DIR_PARENT        :       241 ( 3.07%)
		FOUND_DIR_GRANDPARENT   :        20 ( 0.26%)
		FOUND_ANY_CHILD         :       151 ( 1.93%)
		FOUND_CHILD_PARTIAL     :        16 ( 0.20%)
		FOUND_OTHER             :       124 ( 1.58%)
		FAIL                    :      2353 (30.01%)
```

</details>