### PR TITLE
CU-8695pvhfe fix usage monitoring for multiprocessing

### DIFF
--- a/tests/utils/test_usage_monitoring.py
+++ b/tests/utils/test_usage_monitoring.py
@@ -89,7 +89,7 @@ class InterMediateUsageMonitorTests(UsageMonitorBaseTests):
         self.assertEqual(len(lines), self.expected_in_file)
 
 
-class UMT(UsageMonitorBaseTests):
+class UsageMonitoringAutoTests(UsageMonitorBaseTests):
     ENABLED_DICT = {
         "MEDCAT_USAGE_LOGS": "True",
         "MEDCAT_USAGE_LOGS_LOCATION": "."


### PR DESCRIPTION
Previously usage monitoring wouldn't work for multiprocessing.

The issue was 2-fold.
1. For `CAT.get_entities_multi_texts` and `CAT.multiprocessing_batch_docs_size` (which uses the former internally)
   - Uses the `CAT.pipe` and `Pipe.batch_multi_processHad` directly
   - Had to add logging to the input/output separately
2. For `CAT.multiprocessing_batch_char_size`
   - Runs on different processes, which means that different instances are used
      - And (for some reason) cleanup (i.e a `__del__` call - which would flush automatically) is not done
   - Had to flush the usage monitor (i.e write to disk) at the end of each multiprocessing method (`CAT._mp_cons`) explicitly


The PR also adds tests to make sure the monitoring actually works as well. The 3 added tests failed in the previous state of the project.