### PR TITLE
CU-86964zm4d fix preprocessing

### DIFF
--- a/medcat/utils/preprocess_snomed.py
+++ b/medcat/utils/preprocess_snomed.py
@@ -329,7 +329,7 @@ class Snomed:
             contents_path = os.path.join(self.paths[i], PER_FILE_TYPE_PATHS[RefSetFileType.concept])
             concept_snapshot = self._extension.value.exp_files.get_concept()
             description_snapshot = self._extension.value.exp_files.get_description()
-            if concept_snapshot in (None, _IGNORE_TAG) or (
+            if concept_snapshot is None or _IGNORE_TAG in concept_snapshot or (
                     self.bundle and self.bundle.value.has_invalid(
                         self._extension, [RefSetFileType.concept, RefSetFileType.description])):
                 continue
@@ -404,7 +404,7 @@ class Snomed:
             contents_path = os.path.join(self.paths[i], PER_FILE_TYPE_PATHS[RefSetFileType.concept])
             concept_snapshot = self._extension.value.exp_files.get_concept()
             relationship_snapshot = self._extension.value.exp_files.get_relationship()
-            if concept_snapshot in (None, _IGNORE_TAG) or (
+            if concept_snapshot is None or _IGNORE_TAG in concept_snapshot or (
                     self.bundle and self.bundle.value.has_invalid(
                         self._extension, [RefSetFileType.concept, RefSetFileType.description])):
                 continue
@@ -440,7 +440,7 @@ class Snomed:
             contents_path = os.path.join(self.paths[i], PER_FILE_TYPE_PATHS[RefSetFileType.concept])
             concept_snapshot = self._extension.value.exp_files.get_concept()
             relationship_snapshot = self._extension.value.exp_files.get_relationship()
-            if concept_snapshot in (None, _IGNORE_TAG) or (
+            if concept_snapshot is None or _IGNORE_TAG in concept_snapshot or (
                     self.bundle and self.bundle.value.has_invalid(
                         self._extension, [RefSetFileType.concept, RefSetFileType.description])):
                 continue
@@ -566,7 +566,7 @@ class Snomed:
             self._set_extension(snomed_release, self.exts[i])
             refset_terminology = os.path.join(self.paths[i], PER_FILE_TYPE_PATHS[RefSetFileType.refset])
             icd10_ref_set = self._extension.value.exp_files.get_refset()
-            if icd10_ref_set in (None, _IGNORE_TAG) or (
+            if icd10_ref_set is None or _IGNORE_TAG in icd10_ref_set or (
                     self.bundle and self.bundle.value.has_invalid(
                         self._extension, [RefSetFileType.concept, RefSetFileType.description])):
                 continue

--- a/medcat/utils/preprocess_snomed.py
+++ b/medcat/utils/preprocess_snomed.py
@@ -478,10 +478,7 @@ class Snomed:
             dict: A dictionary containing the SNOMED CT to ICD-10 mappings including metadata.
         """
         snomed2icd10df = self._map_snomed2refset()
-        if self._extension in (SupportedExtension.UK_CLINICAL, SupportedExtension.UK_DRUG):
-            return self._refset_df2dict(snomed2icd10df[0])
-        else:
-            return self._refset_df2dict(snomed2icd10df)
+        return self._refset_df2dict(snomed2icd10df[0])
 
     def map_snomed2opcs4(self) -> dict:
         """
@@ -496,7 +493,8 @@ class Snomed:
         Returns:
             dict: A dictionary containing the SNOMED CT to OPCS-4 mappings including metadata.
         """
-        if self._extension not in (SupportedExtension.UK_CLINICAL, SupportedExtension.UK_DRUG):
+        if all(ext not in (SupportedExtension.UK_CLINICAL, SupportedExtension.UK_DRUG)
+               for ext in self.exts):
             raise AttributeError(
                 "OPCS-4 mapping does not exist in this edition")
         snomed2opcs4df = self._map_snomed2refset()[1]
@@ -584,13 +582,14 @@ class Snomed:
             dfs2merge.append(icd_mappings)
         mapping_df = pd.concat(dfs2merge)
         del dfs2merge
-        if self._extension in (SupportedExtension.UK_CLINICAL, SupportedExtension.UK_DRUG):
+        if any(ext in (SupportedExtension.UK_CLINICAL, SupportedExtension.UK_DRUG)
+               for ext in self.exts):
             opcs_df = mapping_df[mapping_df['refsetId'] == self.opcs_refset_id]
             icd10_df = mapping_df[mapping_df['refsetId']
                                   == '999002271000000101']
             return icd10_df, opcs_df
         else:
-            return mapping_df
+            return mapping_df, None
 
 
 class UnkownSnomedReleaseException(ValueError):

--- a/medcat/utils/preprocess_snomed.py
+++ b/medcat/utils/preprocess_snomed.py
@@ -266,6 +266,7 @@ class Snomed:
 
     def _set_extension(self, release: str, extension: SupportedExtension) -> None:
         # NOTE: now using the later refset IF by default
+        # NOTE: the OPCS4 refset ID is only relevant for UK releases
         self.opcs_refset_id = '1382401000000109'
         if (extension in (SupportedExtension.UK_CLINICAL, SupportedExtension.UK_DRUG) and
                 # using lexicographical comparison below

--- a/medcat/utils/preprocess_snomed.py
+++ b/medcat/utils/preprocess_snomed.py
@@ -265,15 +265,16 @@ class Snomed:
         return None
 
     def _set_extension(self, release: str, extension: SupportedExtension) -> None:
-        self.opcs_refset_id = "1126441000000105"
+        # NOTE: now using the later refset IF by default
+        self.opcs_refset_id = '1382401000000109'
         if (extension in (SupportedExtension.UK_CLINICAL, SupportedExtension.UK_DRUG) and
                 # using lexicographical comparison below
                 # e.g "20240101" > "20231122" results in True
                 # yet "20231121" > "20231122" results in False
-                len(release) == len("20231122") and release >= "20231122"):
+                len(release) == len("20231122") and release < "20231122"):
             # NOTE for UK extensions starting from 20231122 the
             #      OPCS4 refset ID seems to be different
-            self.opcs_refset_id = '1382401000000109'
+            self.opcs_refset_id = "1126441000000105"
         self._extension = extension
 
     @classmethod

--- a/tests/utils/test_preprocess_snomed.py
+++ b/tests/utils/test_preprocess_snomed.py
@@ -51,6 +51,7 @@ class DirectMappingTest(unittest.TestCase):
 
 
 EXAMPLE_SNOMED_PATH_OLD = "SnomedCT_InternationalRF2_PRODUCTION_20220831T120000Z"
+EXAMPLE_SNOMED_PATH_OLD_UK = "SnomedCT_UKClinicalRF2_PRODUCTION_20220831T120000Z"
 EXAMPLE_SNOMED_PATH_NEW = "SnomedCT_UKClinicalRF2_PRODUCTION_20231122T000001Z"
 
 
@@ -87,6 +88,13 @@ class TestSnomedVersionsOPCS4(unittest.TestCase):
             snomed = preprocess_snomed.Snomed(EXAMPLE_SNOMED_PATH_OLD)
         snomed._set_extension(snomed._determine_release(EXAMPLE_SNOMED_PATH_OLD),
                               snomed._determine_extension(EXAMPLE_SNOMED_PATH_OLD))
+        self.assertEqual(snomed.opcs_refset_id, "1382401000000109")  # defaults to this now
+
+    def test_old_gets_old_OPCS4_mapping_UK(self):
+        with patch_fake_files(EXAMPLE_SNOMED_PATH_OLD_UK):
+            snomed = preprocess_snomed.Snomed(EXAMPLE_SNOMED_PATH_OLD_UK)
+        snomed._set_extension(snomed._determine_release(EXAMPLE_SNOMED_PATH_OLD_UK),
+                              snomed._determine_extension(EXAMPLE_SNOMED_PATH_OLD_UK))
         self.assertEqual(snomed.opcs_refset_id, "1126441000000105")
 
     def test_new_gets_new_OCPS4_mapping(self):


### PR DESCRIPTION
Since #469 there's been a bit of an issue with preprocessing. Namely, it wasn't ignoring `UKClinicalRefsetsRF2` as it should have done.

I have made the necessary change.

The other small QoL change this PR introduces is the OPCS4 refset ID. Since end of 2023 the refset ID for OCS4 mappings is different. But the default had been the old ID. This PR reversed that logic and has the new refset ID as a default rather than the old one and changes to the old one if/when needed.

And the third thing that was problematic was checking of extension (e.g UK/UK Drug) outside the loop since extensions are now handled automatically and can change while iterating over them in a bundle.

To ensure this all works exactly as it should I ran a test on Snomed UK Clinical Edition and Drug Extension releases with both the old version (i.e one available with medcat 1.12) and this version. And the results were identical in terms of:
- Output of `Snomed.to_concept_df`
- Output of `Snomed.map_snomed2icd10`
- Output of `Snomed.map_snomed2opcs4`
- Output of `Snomed.relationship2json` with relationship code `"116680003"` (ISA relationships)