### PR TITLE
CU-86967nnra Drop python 3.8 support (EoL)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
       max-parallel: 4
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     packages=['medcat', 'medcat.utils', 'medcat.preprocessing', 'medcat.ner', 'medcat.linking', 'medcat.datasets',
               'medcat.tokenizers', 'medcat.utils.meta_cat', 'medcat.pipeline', 'medcat.utils.ner', 'medcat.utils.relation_extraction',
               'medcat.utils.saving', 'medcat.utils.regression', 'medcat.stats'],
-    python_requires='>=3.9, <3.12', # 3.8 is EoL, 3.12 support is currently waiting on spacy
+    python_requires='>=3.9', # 3.8 is EoL
     install_requires=install_requires,
     include_package_data=True,
     package_data={"medcat": ["install_requires.txt"]},

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setuptools.setup(
     package_data={"medcat": ["install_requires.txt"]},
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
     packages=['medcat', 'medcat.utils', 'medcat.preprocessing', 'medcat.ner', 'medcat.linking', 'medcat.datasets',
               'medcat.tokenizers', 'medcat.utils.meta_cat', 'medcat.pipeline', 'medcat.utils.ner', 'medcat.utils.relation_extraction',
               'medcat.utils.saving', 'medcat.utils.regression', 'medcat.stats'],
+    python_requires='>=3.9, <3.12', # 3.8 is EoL, 3.12 support is currently waiting on spacy
     install_requires=install_requires,
     include_package_data=True,
     package_data={"medcat": ["install_requires.txt"]},


### PR DESCRIPTION
Python 3.8 is EoL since 7th of October. As such, it's time to stop support for it.

That is what this PR does. It:
- removes 3.8 from GitHub Actions workflow,
- removes 3.8 from classifiers,
- adds `python_requires='>=3.9'` to `setup.py` to disallow installation older python versions
  - 3.8 is end of life

NOTE:
I considered adding a cap for newer python versions as well, but I didn't think it made sense in the large scheme of things since 3.12 support is held up behind `spacy` 3.12 support (which should be at `spacy==2.4.0`). It's not really under our control. It's also not currently possible to install `medcat` on these newer python versions anyway (due to no compatible `spacy`).
