### PR TITLE
CU-8696n7w95: Remove commented code to fix DeID (oversight in PR 490)

### DIFF
--- a/medcat/ner/transformers_ner.py
+++ b/medcat/ner/transformers_ner.py
@@ -87,10 +87,10 @@ class TransformersNER(object):
             # NOTE: this will fix the DeID model(s) created before medcat 1.9.3
             #       though this fix may very well be unstable
             self.ner_pipe.tokenizer._in_target_context_manager = False
-        # if not hasattr(self.ner_pipe.tokenizer, 'split_special_tokens'):
-        #     # NOTE: this will fix the DeID model(s) created with transformers before 4.42
-        #     #       and allow them to run with later transforemrs
-        #     self.ner_pipe.tokenizer.split_special_tokens = False
+        if not hasattr(self.ner_pipe.tokenizer, 'split_special_tokens'):
+            # NOTE: this will fix the DeID model(s) created with transformers before 4.42
+            #       and allow them to run with later transforemrs
+            self.ner_pipe.tokenizer.split_special_tokens = False
         self.ner_pipe.device = self.model.device
         self._consecutive_identical_failures = 0
         self._last_exception: Optional[Tuple[str, Type[Exception]]] = None


### PR DESCRIPTION
Refer to issue #501 

Apparently this snippet of code was (accidentally!) commented out when working towards #490 (in commit https://github.com/CogStack/MedCAT/pull/490/commits/5bb188d08b531a08adf9e06ea97c7c8a577043e8).

So this PR will fix that.