### PR TITLE
CU-8696v2j42: Add test to make sure per-cui counts are kept when creating folds

### DIFF
--- a/tests/stats/test_kfold.py
+++ b/tests/stats/test_kfold.py
@@ -2,6 +2,7 @@ import os
 import json
 from typing import Dict, Union, Optional
 from copy import deepcopy
+from collections import Counter
 
 from medcat.stats import kfold
 from medcat.cat import CAT
@@ -84,6 +85,20 @@ class KFoldCreatorTests(MCTExportTests):
             total_anns += anns
         count_all_once = kfold.count_all_annotations(self.mct_export)
         self.assertEqual(total_anns, count_all_once)
+
+    def count_cuis(self, export: MCTExportTests) -> Counter:
+        cntr = Counter()
+        for _, _, ann in kfold.iter_anns(export):
+            cui = ann["cui"]
+            cntr[cui] += 1
+        return cntr
+
+    def test_folds_keep_ann_targets(self):
+        orig_cntr = self.count_cuis(self.mct_export)
+        fold_counter = Counter()
+        for fold in self.folds:
+            fold_counter += self.count_cuis(fold)
+        self.assertEqual(orig_cntr, fold_counter)
 
     def test_1fold_same_as_orig(self):
         folds = kfold.get_fold_creator(self.mct_export, 1, split_type=self.SPLIT_TYPE).create_folds()


### PR DESCRIPTION
Currently, when splitting per-annotations, not all annotations are used.
In fact, only the annotations from the first few documents/projects would be used.
That is because for each fold, the number of annotations already used is not considered.

The PR adds a test to show that this is currently problematic (first commit).
And then introduces the relevant fix.