### PR TITLE
CU-8697x7y9x: Fix issue with transformers 4.47+ affecting DeID

### DIFF
--- a/medcat/utils/relation_extraction/utils.py
+++ b/medcat/utils/relation_extraction/utils.py
@@ -146,7 +146,7 @@ def load_state(model: BertModel_RelationExtraction, optimizer, scheduler, path="
 
         if optimizer is None:
             optimizer = torch.optim.Adam(
-                [{"params": model.module.parameters(), "lr": config.train.lr}])
+                [{"params": model.module.parameters(), "lr": config.train.lr}])  # type: ignore
 
         if scheduler is None:
             scheduler = torch.optim.lr_scheduler.MultiStepLR(optimizer,


### PR DESCRIPTION
Since `transformers==4.47.0` there's a different way they handle some of the tokenizer attributes (see https://github.com/huggingface/transformers/pull/34461). But our saved models have no idea of this change and keep the data in the old format. So when trying to run the DeID model, the new method is used to read the data, but there's nothing there to be read.

We haven't seen anyone really complain about this, but it's mostly due to the insallations being static. If someone installed before 17th of December, their installation would have `transformers<4.47` and unless they've updated since, their setup will still work just fine.

This PR fixes that. It moves the relevant data to the correct location upon creation of pipeline.

<details>
<summary>Verification that this fixes the issue</summary>
Ran on master branch:

```
% python -c "from medcat.utils.ner.deid import DeIdModel;model = DeIdModel.load_model_pack(\"temp/mct_1_15_beta_2025_02_11/medcat_deid_model_691c3f6a6e5400e7.zip\");print(model.deid_text('Patient: Mr James Doe'))"
/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/training_args.py:1575: FutureWarning: `evaluation_strategy` is deprecated and will be removed in version 4.46 of 🤗 Transformers. Use `eval_strategy` instead
  warnings.warn(
Using the `WANDB_DISABLED` environment variable is deprecated and will be removed in v5. Use the --report_to flag to control the integrations used for logging result (for instance --report_to none).
Device set to use mps:0
/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/spacy/util.py:910: UserWarning: [W095] Model 'en_core_web_md' (3.1.0) was trained with spaCy v3.1.0 and may not be 100% compatible with the current version (3.7.5). If you see errors or degraded performance, download a newer compatible model or retrain your custom model with the current spaCy version. For more details and available updates, run: python -m spacy validate
  warnings.warn(warn_msg)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/medcat/utils/ner/deid.py", line 85, in deid_text
    entities = self.cat.get_entities(text)['entities']
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/medcat/cat.py", line 1094, in get_entities
    doc = self(text)
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/medcat/cat.py", line 526, in __call__
    return self.pipe(text)  # type: ignore
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/medcat/pipe.py", line 278, in __call__
    return self._nlp(text) if len(text) > 0 else None  # type: ignore
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/spacy/language.py", line 1054, in __call__
    error_handler(name, proc, [doc], e)
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/spacy/util.py", line 1722, in raise_error
    raise e
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/spacy/language.py", line 1049, in __call__
    doc = proc(doc, **component_cfg.get(name, {}))  # type: ignore[call-arg]
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/medcat/ner/transformers_ner.py", line 442, in __call__
    doc = next(self.pipe(iter([doc])))
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/medcat/ner/transformers_ner.py", line 389, in pipe
    yield from self._process(stream, batch_size_chars)  # type: ignore
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/medcat/ner/transformers_ner.py", line 399, in _process
    res = self.ner_pipe(doc.text, aggregation_strategy=self.config.general['ner_aggregation_strategy'])
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/pipelines/token_classification.py", line 250, in __call__
    return super().__call__(inputs, **kwargs)
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/pipelines/base.py", line 1354, in __call__
    return next(
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/pipelines/pt_utils.py", line 124, in __next__
    item = next(self.iterator)
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/pipelines/pt_utils.py", line 269, in __next__
    processed = self.infer(next(self.iterator), **self.params)
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 631, in __next__
    data = self._next_data()
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 675, in _next_data
    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py", line 32, in fetch
    data.append(next(self.dataset_iter))
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/pipelines/pt_utils.py", line 186, in __next__
    processed = next(self.subiterator)
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/pipelines/token_classification.py", line 255, in preprocess
    inputs = self.tokenizer(
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 2868, in __call__
    encodings = self._call_one(text=text, text_pair=text_pair, **all_kwargs)
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 2978, in _call_one
    return self.encode_plus(
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 3045, in encode_plus
    padding_strategy, truncation_strategy, max_length, kwargs = self._get_padding_truncation_strategies(
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 2769, in _get_padding_truncation_strategies
    if padding_strategy != PaddingStrategy.DO_NOT_PAD and (self.pad_token is None or self.pad_token_id < 0):
  File "/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 1108, in __getattr__
    raise AttributeError(f"{self.__class__.__name__} has no attribute {key}")
AttributeError: RobertaTokenizerFast has no attribute pad_token. Did you mean: '_pad_token'?
```
And after the changes:

```
% python -c "from medcat.utils.ner.deid import DeIdModel;model = DeIdModel.load_model_pack(\"temp/mct_1_15_beta_2025_02_11/medcat_deid_model_691c3f6a6e5400e7.zip\");print(model.deid_text('Patient: Mr James Doe'))"
/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/transformers/training_args.py:1575: FutureWarning: `evaluation_strategy` is deprecated and will be removed in version 4.46 of 🤗 Transformers. Use `eval_strategy` instead
  warnings.warn(
Using the `WANDB_DISABLED` environment variable is deprecated and will be removed in v5. Use the --report_to flag to control the integrations used for logging result (for instance --report_to none).
Device set to use mps:0
/Users/martratas/Documents/CogStack/.MedCAT.nosync/MedCAT/.venv3.10.13/lib/python3.10/site-packages/spacy/util.py:910: UserWarning: [W095] Model 'en_core_web_md' (3.1.0) was trained with spaCy v3.1.0 and may not be 100% compatible with the current version (3.7.5). If you see errors or degraded performance, download a newer compatible model or retrain your custom model with the current spaCy version. For more details and available updates, run: python -m spacy validate
  warnings.warn(warn_msg)
Patient: Mr [Name]
```
</details>