### PR TITLE
CU-8698ek477: Fix AdamW import from tranformers to torch

### DIFF
--- a/medcat/utils/meta_cat/ml_utils.py
+++ b/medcat/utils/meta_cat/ml_utils.py
@@ -14,7 +14,7 @@ from medcat.tokenizers.meta_cat_tokenizers import TokenizerWrapperBase
 from sklearn.metrics import classification_report, precision_recall_fscore_support, confusion_matrix
 from sklearn.model_selection import train_test_split
 from sklearn.utils.class_weight import compute_class_weight
-from transformers import AdamW, get_linear_schedule_with_warmup
+from transformers import AdamW, get_linear_schedule_with_warmup  # TODO: import from troch.optim instead
 
 
 import logging

--- a/medcat/utils/meta_cat/ml_utils.py
+++ b/medcat/utils/meta_cat/ml_utils.py
@@ -14,7 +14,8 @@ from medcat.tokenizers.meta_cat_tokenizers import TokenizerWrapperBase
 from sklearn.metrics import classification_report, precision_recall_fscore_support, confusion_matrix
 from sklearn.model_selection import train_test_split
 from sklearn.utils.class_weight import compute_class_weight
-from transformers import AdamW, get_linear_schedule_with_warmup  # TODO: import from troch.optim instead
+from transformers import get_linear_schedule_with_warmup
+from torch.optim import AdamW
 
 
 import logging


### PR DESCRIPTION
In `transformers==4.50.0` the `AdamW` implementation was removed and the suggestion was to use the version in `torch.optim` instead:
https://github.com/huggingface/transformers/pull/36177

Before the change to the import (the first commit in thie branch / PR), the GHA workflow will fail due to this import not existing and our loose dependencies.

Though the change is rather simple - just change the import. And the 2nd commit workflow should be successful.