### PR TITLE
CU-8698f8fgc: Fix negative sampling including indices for words without a vector

### DIFF
--- a/medcat/vocab.py
+++ b/medcat/vocab.py
@@ -190,8 +190,19 @@ class Vocab(object):
                            "the creation of a massive array. So therefore, there "
                            "is no need to pass the `table_size` parameter anymore.")
         freqs = []
-        for word in self.vec_index2word.values():
+        # index list maps the slot in which a word index
+        # sits in vec_index2word to the actual index for said word
+        # e.g:
+        #    if we have words indexed 0, 1, and 2
+        #    but only 0, and 2 have corresponding vectors
+        #    then only 0 and 2 will occur in vec_index2word
+        #    and while 0 will be in the 0th position (as expected)
+        #    in the final probability list, 2 will be in 1st position
+        #    so we need to mark that conversion down
+        index_list = []
+        for word_index, word in self.vec_index2word.items():
             freqs.append(self[word])
+            index_list.append(word_index)
 
         # Power and normalize frequencies
         freqs = np.array(freqs) ** (3/4)
@@ -199,6 +210,8 @@ class Vocab(object):
 
         # Calculate cumulative probabilities
         self.cum_probs = np.cumsum(freqs)
+        # the mapping from vector index order to word indices
+        self._index_list = index_list
 
     def get_negative_samples(self, n: int = 6, ignore_punct_and_num: bool = False) -> List[int]:
         """Get N negative samples.
@@ -216,8 +229,11 @@ class Vocab(object):
         if len(self.cum_probs) == 0:
             self.make_unigram_table()
         random_vals = np.random.rand(n)
-        # NOTE: there's a change in numpy
-        inds = cast(List[int], np.searchsorted(self.cum_probs, random_vals).tolist())
+        # NOTE: These indices are in terms of the cum_probs array
+        #       which only has word data for words with vectors.
+        vec_slots = cast(List[int], np.searchsorted(self.cum_probs, random_vals).tolist())
+        # so we need to translate these back to word indices
+        inds = list(map(self._index_list.__getitem__, vec_slots))
 
         if ignore_punct_and_num:
             # Do not return anything that does not have letters in it

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -73,7 +73,7 @@ class VocabUnigramTableTests(unittest.TestCase):
         for _ in range(cls.NUM_TIMES):
             got = cls.vocab.get_negative_samples(cls.NUM_SAMPLES)
             c += Counter(got)
-        total = c.total()
+        total = sum(c.values())
         got_freqs = {index: val/total for index, val in c.items()}
         return got_freqs
 

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -43,12 +43,16 @@ class VocabUnigramTableTests(unittest.TestCase):
                                      "..", "examples", "vocab_data.txt")
     UNIGRAM_TABLE_SIZE = 10_000
     # found that this seed had the closest frequency at the sample size we're at
-    RANDOM_SEED = 4976
+    RANDOM_SEED = 32
     NUM_SAMPLES = 20 # NOTE: 3, 9, 18, and 27 at a time are regular due to context vector sizes
     NUM_TIMES = 200
-    # based on the counts on vocab_data.txt and the one set in setUpClass
-    # EXPECTED_FREQUENCIES = [0.62218692, 0.32422858, 0.0535845]
-    EXPECTED_FREQUENCIES = [0.04875, 0.316, 0.61075, 0.0245]
+    # based on the counts on vocab_data.txt and the ones set in setUpClass
+    # plus the power of 3/4
+    EXPECTED_FREQUENCIES = {
+        0: 0.61078822, 1: 0.3182886,
+        2: 0.05260281,
+        # NOTE: no 3 since that's got no vectors
+        4: 0.01832037}
     TOLERANCE = 0.001
 
     @classmethod
@@ -64,19 +68,29 @@ class VocabUnigramTableTests(unittest.TestCase):
         np.random.seed(self.RANDOM_SEED)
 
     @classmethod
-    def _get_freqs(cls) -> list[float]:
+    def _get_freqs(cls) -> dict[int, float]:
         c = Counter()
         for _ in range(cls.NUM_TIMES):
             got = cls.vocab.get_negative_samples(cls.NUM_SAMPLES)
             c += Counter(got)
-        total = sum(c[i] for i in c)
-        got_freqs = [c[i]/total for i in c]
+        total = c.total()
+        got_freqs = {index: val/total for index, val in c.items()}
         return got_freqs
 
-    def assert_accurate_enough(self, got_freqs: list[float]):
+    @classmethod
+    def _get_abs_max_diff(cls, dict1: dict[int, float],
+                          dict2: dict[int, float]):
+        assert dict1.keys() == dict2.keys()
+        vals1, vals2 = [], []
+        for index in dict1:
+            vals1.append(dict1[index])
+            vals2.append(dict2[index])
+        return np.max(np.abs(np.array(vals1) - np.array(vals2)))
+
+    def assert_accurate_enough(self, got_freqs: dict[int, float]):
+        self.assertEqual(got_freqs.keys(), self.EXPECTED_FREQUENCIES.keys())
         self.assertTrue(
-            np.max(np.abs(np.array(got_freqs) - self.EXPECTED_FREQUENCIES)) < self.TOLERANCE
-        )
+            self._get_abs_max_diff(self.EXPECTED_FREQUENCIES, got_freqs) < self.TOLERANCE)
 
     def test_does_not_include_vectorless_indices(self, num_samples: int = 100):
         inds = self.vocab.get_negative_samples(num_samples)


### PR DESCRIPTION
MedCAT 1.15.0 (more specifically PR #503) removed the unigram table in favour of an approach that doesn't need the massive array that was used before.

However, during the implementation, some details were overlooked. Namely, the `Vocab` keeps track of two `dict`s. One for `index2word` and another for `vec_index2word`. The `index2word` map just maps the first `N` (the number of words in the vocab) postive integers to the corresponding word. The `vec_index2word` map does the same, however it omits words that don't have a corresponding vector. E.g it could have keys `[0, 1, 2, 4, 10, 15]`  - missing indices that don't have a corresponding word vector.
Now, when the cumulative frequencies are created, the original PR made the assumption that `vec_index2word` also maps all consecutive integers. And as such, the index at which the cumulative probabilities were found to match was expected to be the index for each word. However, in reality it was the slot for said index in `vec_index2word`.

In order to fix this, we'll need to remap the slot indices to word indices.


So what this PR does is exactly that. It creates a mapping from the "slot indices" in the to `vec_index2word` to the actual word indices. And then subsequently uses the mapping to map back to the actual word indices at sampling time.
The PR also adds a new test for this as well. Something that makes sure that negative sampling doesn't return indices corresponding the words with no vectors.

PS:
The GHA workflow for the first commit will fail because it just adds the test (that will now fail).
The second commit provides the actual fix.