### PR TITLE
CU-8698gqumv: Fix regression test vocab vector sizes

### DIFF
--- a/tests/resources/regression/run_regression.sh
+++ b/tests/resources/regression/run_regression.sh
@@ -14,6 +14,10 @@ echo "$output"
 model_path=$(echo "$output" | tail -n 1)
 # NOTE: this file should be tagged with the python version we're using
 
+# test the vocab to make sure it's all good
+python tests/resources/regression/test_vocab.py
+# TODO: test other things as well?
+
 # run the regression_checker with the captured file path
 # if any of the regression cases fail, this will return a non-zero exit status
 python -m medcat.utils.regression.regression_checker \

--- a/tests/resources/regression/test_vocab.py
+++ b/tests/resources/regression/test_vocab.py
@@ -1,0 +1,31 @@
+import os
+
+from medcat.vocab import Vocab
+
+import unittest
+
+
+class RegressionModelVocabTests(unittest.TestCase):
+    VOCAB_DATA_PATH = os.path.join(os.path.dirname(__file__),
+                              'creation', 'vocab_data.txt')
+
+    @classmethod
+    def setUpClass(cls):
+        cls.vocab = Vocab()
+        cls.vocab.add_words(cls.VOCAB_DATA_PATH)
+
+    def test_has_same_vector_lengths(self):
+        all_lengths = set()
+        for w in self.vocab.vec_index2word.values():
+            all_lengths.add(len(self.vocab.vec(w)))
+        self.assertEqual(len(all_lengths), 1, f"Expected equal lengths. Got: {all_lengths}")
+
+    def test_all_words_have_vectors(self):
+        for w in self.vocab.vocab:
+            with self.subTest(f"Word: {repr(w)}"):
+                # NOTE: if not there, will raise an exception
+                self.assertIsNotNone(self.vocab.vec(w))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Turns out one of the vectors was of length 8, the others of lenght 7.
Somehow MedCAT was able to recover, but this still isn't ideal.

