### PR TITLE
CU-8698veb6y: Use Ubuntu 24.04 for publishing to test PyPI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
       github.ref == 'refs/heads/master' &&
       github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags') != true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     concurrency: publish-to-test-pypi
     needs: [build]


### PR DESCRIPTION
The publishing to test PyPI in the main workflow was failing due to using Ubuntu 20.04 which was removed at 2025-04-15.

This PR updates the runner to Ubuntu 24.04.