### PR TITLE
CU-8698vj59x: Use Ubuntu 24.04 for production workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-n-publish-to-pypi:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency: build-n-publish-to-pypi
     if: github.repository == 'CogStack/MedCAT'
 


### PR DESCRIPTION
Similar to #533 - production workflow also needed this change.

PS:
Already made the change on the production branch.