### PR TITLE
CU-8698x2k5b Fix read the docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,5 +15,5 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
-    - method: setuptools
+    - method: pip
       path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=6.2", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]


### PR DESCRIPTION
ReadTheDocs builds are now failing.
Turns out that's because `pip==25.1` now removes the build process that's used on there (see [release notes](https://pip.pypa.io/en/stable/news/#:~:text=Deprecate%20the%20legacy%20setup.py%20bdist_wheel%20mechanism.%20To%20silence%20the%20warning%2C%20and%20future%2Dproof%20their%20setup%2C%20users%20should%20enable%20%2D%2Duse%2Dpep517%20or%20add%20a%20pyproject.toml%20file%20to%20the%20projects%20they%20control.%20(%2313319))).
So we are now forced to use a minimal `pyproject.toml`.
Though notably, we can get away with still using setup.py for most of the installation process.

So this PR will make that change.

The docs builds should work with this change alone. But I will - of course - make sure they do be enabling this branch as a version temporarily.