### PR TITLE
CU-8698x5ehn Notification of final v1 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Medical  <img src="https://raw.githubusercontent.com/CogStack/MedCAT/master/media/cat-logo.png" width=45> oncept Annotation Tool
 
+**NB! MedCAT v2 will soon be released.**
+**MedCAT v1.16.0 will be the latest MedCAT v1 minor release.**
+**However, we will likely continue to support v1.16.x with patch releases for some time.**
+
 [![Build Status](https://github.com/CogStack/MedCAT/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/CogStack/MedCAT/actions/workflows/main.yml?query=branch%3Amaster)
 [![Documentation Status](https://readthedocs.org/projects/medcat/badge/?version=latest)](https://medcat.readthedocs.io/en/latest/?badge=latest)
 [![Latest release](https://img.shields.io/github/v/release/CogStack/MedCAT)](https://github.com/CogStack/MedCAT/releases/latest)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Normal installations of MedCAT will install torch-gpu and all relevant dependanc
 
 To install the latest version of MedCAT without torch GPU support run the following command:
 ```
-pip install medcat --extra_index_url https://download.pytorch.org/whl/cpu/
+pip install medcat --extra-index-url https://download.pytorch.org/whl/cpu/
 ```
 ## Demo
 A demo application is available at [MedCAT](https://medcat.rosalind.kcl.ac.uk). This was trained on MIMIC-III and all of SNOMED-CT.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Medical  <img src="https://raw.githubusercontent.com/CogStack/MedCAT/master/media/cat-logo.png" width=45> oncept Annotation Tool
 
-**NB! MedCAT v2 will soon be released.**
+**NB! [MedCAT v2](https://github.com/CogStack/MedCAT2) will soon be released.**
 **MedCAT v1.16.0 will be the latest MedCAT v1 minor release.**
 **However, we will likely continue to support v1.16.x with patch releases for some time.**
 


### PR DESCRIPTION
This PR notifies that v1.16 will be the latest minor relase of MedCAT v1 and adds a link to v2.

It also fixes a long-standing minor mistake with no-gpu torch installation in the docs.