### PR TITLE
Migrate to `logger.warning` usage

### DIFF
--- a/medcat/utils/helpers.py
+++ b/medcat/utils/helpers.py
@@ -254,7 +254,7 @@ def umls_to_icd10cm(cdb, csv_path):
                     else:
                         cdb.cui2info[cui]["icd10"] = [icd10]
         except Exception as e:
-            logger.warn("Issue at %s", row["CUI"], exc_info=e)
+            logger.warning("Issue at %s", row["CUI"], exc_info=e)
 
 
 def umls_to_icd10_over_snomed(cdb, pickle_path):
@@ -320,7 +320,7 @@ def umls_to_icd10(cdb: CDB, csv_path: str):
                 else:
                     cdb.cui2info[cui]["icd10"] = [icd10]
         except Exception as e:
-            logger.warn("Issue at %s", row["CUI"], exc_info=e)
+            logger.warning("Issue at %s", row["CUI"], exc_info=e)
 
 
 def umls_to_snomed(cdb: CDB, pickle_path):
@@ -452,7 +452,7 @@ def add_names_icd10(csv_path, cat):
             name = row['name']
             cat.add_name(cui, name, is_pref_name=False, only_new=True)
         except Exception as e:
-            logger.warn("Issue at %s", row["CUI"], exc_info=e)
+            logger.warning("Issue at %s", row["CUI"], exc_info=e)
 
         if index % 1000 == 0:
             logger.info('index=%d', index)
@@ -472,7 +472,7 @@ def add_names_icd10cm(cdb, csv_path, cat):
                 if bl != len(cdb.cui2names.get(cui, [])):
                     logger.info("'%s' with cui '%s'", name, cui)
         except Exception as e:
-            logger.warn("Issue at %s", row["CUI"], exc_info=e)
+            logger.warning("Issue at %s", row["CUI"], exc_info=e)
             break
 
         if index % 1000 == 0:

--- a/medcat/utils/regression/checking.py
+++ b/medcat/utils/regression/checking.py
@@ -228,7 +228,7 @@ def get_ontology_and_version(model_card: dict) -> Tuple[str, str]:
         else:
             raise KeyError(f"Unknown source ontology: {ont_list}")
     except KeyError as key_err:
-        logger.warn(
+        logger.warning(
             "Didn't find the expected source ontology from the model card!", exc_info=key_err)
         return UNKNOWN_METADATA, UNKNOWN_METADATA
     # find ontology
@@ -452,7 +452,7 @@ class RegressionSuite:
             add_case = RegressionCase.from_dict(case_name, details)
             cases.append(add_case)
         if 'meta' not in in_dict:
-            logger.warn("Loading regression suite without any meta data")
+            logger.warning("Loading regression suite without any meta data")
             metadata = MetaData.unknown()
         else:
             metadata = MetaData.parse_obj(in_dict['meta'])


### PR DESCRIPTION
# PR Summary
This small PR resolves the `logger.warn()` deprecation warnings:
```python
/home/runner/work/MedCAT/MedCAT/medcat/utils/regression/checking.py:455: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```